### PR TITLE
change `.env.local.example` for easier setup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,3 @@
-NEXT_PUBLIC_SUPABASE_URL=<your_supabase_project_url>
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<your_supabase_anon_key>
+NEXT_PUBLIC_SUPABASE_URL=https://xyzcompany.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 NEXT_PUBLIC_REDIRECT_URL=http://localhost:3000 # or the production URL


### PR DESCRIPTION
this change allows users to simply copy paste the dummy variables into their own env file without encountering errors.