### PR TITLE
fix transition bug on hero button

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -96,7 +96,7 @@ export default function Hero() {
                   </Link>
                 </Button>
               </div>
-              <div data-aos="fade-up" data-ao s-delay="600">
+              <div data-aos="fade-up" data-aos-delay="500">
                 <Button
                   asChild
                   size={"lg"}


### PR DESCRIPTION
the fade in transition was not applied to the `More Details` button because of a typo.

bug:
![ezgif-1-5275c6c7d0](https://github.com/trypear/pear-landing-page/assets/87584757/1d5d84eb-609e-488a-af50-088a125ad976)

fix:
![fix](https://github.com/trypear/pear-landing-page/assets/87584757/216411f8-6a84-44b4-b9cb-b3a0180e083f)
