### PR TITLE
Fix footer links alignment and spacing for mobile screens

### DIFF
--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -24,13 +24,13 @@ export default function Footer() {
                   Terms of Service
                 </Link>
               </div>
-              <div className="ml-4 mr-4 text-sm text-gray-600">
+              <div className="ml-3 mr-4 mt-4 text-sm text-gray-600 md:mt-0">
                 &copy; Pear AI - All rights reserved.
               </div>
             </div>
             {/* Right side - social links */}
             <ul className="mb-4 mt-2 flex md:order-1 md:mb-0 md:ml-4 md:mt-0">
-              <li className="ml-4">
+              <li className="ml-3">
                 <Link
                   href="https://github.com/orgs/trypear/repositories"
                   target="_blank"


### PR DESCRIPTION
Fix the alignment and spacing of the footer links and copyright for the mobile screens. 

**Before:**
![image](https://github.com/trypear/pear-landing-page/assets/64416825/4b133b17-b25d-4206-a00d-d65f9bf2b96d)

**After:**
![image](https://github.com/trypear/pear-landing-page/assets/64416825/a02ee071-4d03-4124-bae7-b2d6b47be02d)
