### PR TITLE
feat: add loading state to sign in, sign up, and reset password pages

### DIFF
--- a/components/auth/reset-password.tsx
+++ b/components/auth/reset-password.tsx
@@ -5,16 +5,19 @@ import { resetPassword } from "@/app/(auth)/actions";
 import { Button } from "@/components/ui/button";
 
 export default function ResetPassword() {
+  const [isResettingPassword, setIsResettingPassword] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setIsResettingPassword(true);
     setErrorMessage(null);
     const formData = new FormData(e.currentTarget);
     const response = await resetPassword(formData);
     if (response) {
       setErrorMessage(response.error);
     }
+    setIsResettingPassword(false);
   };
   return (
     <section className="relative">
@@ -59,6 +62,8 @@ export default function ResetPassword() {
                   <Button
                     size={"lg"}
                     className="w-full bg-primary-700 text-white-main hover:bg-primary-800 hover:shadow-sm"
+                    disabled={isResettingPassword}
+                    isLoading={isResettingPassword}
                   >
                     Reset Password
                   </Button>

--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -1,21 +1,24 @@
 "use client";
-import Link from "next/link";
-import { useState } from "react";
 import { signin, signinWithGoogle } from "@/app/(auth)/actions";
 import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { useState } from "react";
 import { GoogleLogo } from "../ui/icons";
 
 export default function SignIn() {
+  const [isSigningIn, setIsSigningIn] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleSignIn = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setIsSigningIn(true);
     setErrorMessage(null);
     const formData = new FormData(e.currentTarget);
     const response = await signin(formData);
     if (response) {
       setErrorMessage(response.error);
     }
+    setIsSigningIn(false);
   };
   const handleGoogleSignIn = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -127,6 +130,8 @@ export default function SignIn() {
                   <Button
                     size={"lg"}
                     className="w-full bg-primary-700 text-white-main hover:bg-primary-800 hover:shadow-sm"
+                    disabled={isSigningIn}
+                    isLoading={isSigningIn}
                   >
                     Sign in
                   </Button>

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -6,16 +6,19 @@ import { Button } from "@/components/ui/button";
 import { GoogleLogo } from "../ui/icons";
 
 export default function SignUp() {
+  const [isSigningUp, setIsSigningUp] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleSignUp = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setIsSigningUp(true);
     setErrorMessage(null);
     const formData = new FormData(e.currentTarget);
     const response = await signup(formData);
     if (response) {
       setErrorMessage(response.error);
     }
+    setIsSigningUp(false);
   };
 
   const handleGoogleSignUp = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -155,6 +158,8 @@ export default function SignUp() {
                   <Button
                     size={"lg"}
                     className="w-full bg-primary-700 text-white-main hover:bg-primary-800 hover:shadow-sm"
+                    disabled={isSigningUp}
+                    isLoading={isSigningUp}
                   >
                     Sign up
                   </Button>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -2,9 +2,10 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
+import Spinner from "./spinner";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center gap-2 justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -36,17 +37,38 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  isLoading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      isLoading,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
-      />
+      >
+        {asChild ? (
+          children
+        ) : (
+          <>
+            {children}
+            {isLoading && <Spinner />}
+          </>
+        )}
+      </Comp>
     );
   },
 );

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+import { FC } from "react";
+
+interface SpinnerProps {
+  className?: string;
+}
+
+const Spinner: FC<SpinnerProps> = ({ className, ...props }) => (
+  <div
+    className={cn(
+      "h-4 w-4 animate-spin rounded-full border-2 border-white-main border-t-transparent",
+      className,
+    )}
+    {...props}
+  />
+);
+
+export default Spinner;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -189,6 +189,7 @@ module.exports = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "fadein-opacity": "fadein-opacity 0.6s ease-in-out",
+        spin: "spin .5s linear infinite",
       },
     },
   },

--- a/utils/form-schema.ts
+++ b/utils/form-schema.ts
@@ -5,7 +5,7 @@ export const emailSchema = z.object({
 });
 
 export const passwordSchema = z.object({
-  password: z.string().min(8, { message: "Password not long enough." }),
+  password: z.string().min(8, { message: "Password should be at least 8 characters" }),
 });
 
 export const signUpSchema = z.object({


### PR DESCRIPTION
### Description
Add loading state to sign in, sign up, and reset password pages.

### Changes Made
Integrated loading state into sign in, sign up, and reset password pages
Added spinner component
Refactored button component to accept `isLoading` prop to show the spinner in the button

### Screenshots
https://github.com/trypear/pear-landing-page/assets/64416825/1428053f-d73b-4dd4-9156-54138d8629a8

### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
