### PR TITLE
Add update password page

### DIFF
--- a/app/(auth)/update-password/page.tsx
+++ b/app/(auth)/update-password/page.tsx
@@ -1,6 +1,8 @@
 import UpdatePasswordForm from "@/components/auth/update-password-form";
 import { constructMetadata } from "@/lib/utils";
+import { createClient } from "@/utils/supabase/server";
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = constructMetadata({
   title: "Update password",
@@ -8,13 +10,19 @@ export const metadata: Metadata = constructMetadata({
   canonical: "/update-password",
 });
 
-const UpdatePasswordPage = async () => (
-  <div className="mx-auto max-w-md pt-44 md:pt-32">
-    <h1 className="text-center text-3xl font-semibold md:text-5xl md:font-normal">
-      Update Password
-    </h1>
-    <UpdatePasswordForm />
-  </div>
-);
+export default async function UpdatePasswordPage() {
+  const supabase = createClient();
 
-export default UpdatePasswordPage;
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data?.user) {
+    redirect("/signin");
+  }
+  return (
+    <div className="mx-auto max-w-md pt-44 md:pt-32">
+      <h1 className="text-center text-3xl font-semibold md:text-5xl md:font-normal">
+        Update Password
+      </h1>
+      <UpdatePasswordForm />
+    </div>
+  );
+}

--- a/app/(auth)/update-password/page.tsx
+++ b/app/(auth)/update-password/page.tsx
@@ -1,0 +1,20 @@
+import UpdatePasswordForm from "@/components/auth/update-password-form";
+import { constructMetadata } from "@/lib/utils";
+import { Metadata } from "next";
+
+export const metadata: Metadata = constructMetadata({
+  title: "Update password",
+  description: "Update your account password",
+  canonical: "/update-password",
+});
+
+const UpdatePasswordPage = async () => (
+  <div className="mx-auto max-w-md pt-44 md:pt-32">
+    <h1 className="text-center text-3xl font-semibold md:text-5xl md:font-normal">
+      Update Password
+    </h1>
+    <UpdatePasswordForm />
+  </div>
+);
+
+export default UpdatePasswordPage;

--- a/app/(auth)/update-password/page.tsx
+++ b/app/(auth)/update-password/page.tsx
@@ -17,6 +17,10 @@ export default async function UpdatePasswordPage() {
   if (error || !data?.user) {
     redirect("/signin");
   }
+  // Redirect to the home page if the user is not using email provider
+  if (data.user.app_metadata.provider !== "email") {
+    redirect("/");
+  }
   return (
     <div className="mx-auto max-w-md pt-44 md:pt-32">
       <h1 className="text-center text-3xl font-semibold md:text-5xl md:font-normal">

--- a/components/auth/update-password-form.tsx
+++ b/components/auth/update-password-form.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { constructMetadata } from "@/lib/utils";
+import {
+  UpdatePasswordFormData,
+  updatePasswordSchema,
+} from "@/utils/form-schema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Metadata } from "next";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+export const metadata: Metadata = constructMetadata({
+  title: "Update password",
+  description: "Update your account password",
+  canonical: "/update-password",
+});
+
+const UpdatePasswordForm = () => {
+  const form = useForm<UpdatePasswordFormData>({
+    resolver: zodResolver(updatePasswordSchema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  });
+  const {
+    formState: { isSubmitting },
+  } = form;
+
+  const handleUpdatePassword: SubmitHandler<
+    UpdatePasswordFormData
+  > = async () => {
+    // TODO: Handle the update password functionality
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleUpdatePassword)}
+        className="mt-12 space-y-6 px-6 md:px-0"
+      >
+        <FormField
+          name="password"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel htmlFor="password">New Password</FormLabel>
+              <FormControl>
+                <Input id="password" type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="confirmPassword"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel htmlFor="confirmPassword">
+                Confirm New Password
+              </FormLabel>
+              <FormControl>
+                <Input id="confirmPassword" type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button
+          className="mt-6 w-full rounded-md bg-primary-700 text-white-50 hover:bg-primary-800 hover:shadow-sm"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Updating password..." : "Update Password"}
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export default UpdatePasswordForm;

--- a/utils/form-schema.ts
+++ b/utils/form-schema.ts
@@ -30,6 +30,17 @@ export const resetPasswordSchema = z.object({
   email: emailSchema.shape.email,
 });
 
+export const updatePasswordSchema = z
+  .object({
+    password: passwordSchema.shape.password,
+    confirmPassword: passwordSchema.shape.password,
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
 export type SignUpFormData = z.infer<typeof signUpSchema>;
 export type SignInFormData = z.infer<typeof signInSchema>;
 export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;
+export type UpdatePasswordFormData = z.infer<typeof updatePasswordSchema>;


### PR DESCRIPTION
### Description

This PR adds an update-password page with a form for users to update their password. The form includes the following fields:
- New Password
- Confirm Password

### Related Issue

#104

### Changes Made

- Added update-password page
- Included form with new password and confirm password fields
- Applied validation logic using React Hook Form and Zod

### Screenshots

**Update password page - Desktop**
![image](https://github.com/trypear/pear-landing-page/assets/64416825/f16e5bb8-e1df-41fd-a598-5579b3766f58)

**Update password page - Mobile**
![image](https://github.com/trypear/pear-landing-page/assets/64416825/9cee0f14-fd2d-4cd6-bc10-35aa0dbc3b6b)

**Form Validation**
![image](https://github.com/trypear/pear-landing-page/assets/64416825/8c3a23fd-ee6a-4145-a51c-bc0db69df942)
![image](https://github.com/trypear/pear-landing-page/assets/64416825/e4227bd1-ee6d-4d58-a08f-471c0b1f3e8c)

### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
