### PR TITLE
Standardize URL formatting across the site

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -13,6 +13,7 @@ import {
 } from "@supabase/supabase-js";
 import { UpdatePasswordFormData } from "@/utils/form-schema";
 import { headers } from "next/headers";
+import { getURL } from "@/lib/utils";
 
 export async function signin(formData: FormData) {
   const supabase = createClient();
@@ -91,7 +92,7 @@ export async function signinWithOAuth(provider: Provider) {
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: provider,
     options: {
-      redirectTo: `${protocol}://${host}/auth/callback`,
+      redirectTo: `${getURL()}/auth/callback`,
     },
   });
 
@@ -113,7 +114,7 @@ export async function resetPassword(formData: FormData) {
   const email = formData.get("email") as string;
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_REDIRECT_URL}/update-password`,
+    redirectTo: `${getURL()}/update-password`,
   });
 
   if (error) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -71,3 +71,16 @@ export const constructMetadata = ({
     // },
   };
 };
+
+export const getURL = () => {
+  let url =
+    process?.env?.NEXT_PUBLIC_SITE_URL ??
+    process?.env?.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
+    "http://localhost:3000";
+
+  // Include `https://` when not localhost.
+  url = url.startsWith("http") ? url : `https://${url}`;
+  // Remove trailing slash if present
+  url = url.endsWith("/") ? url.slice(0, -1) : url;
+  return url;
+};


### PR DESCRIPTION
### Description

This PR standardizes URL formatting across the site.

### Changes Made
- Added a utility function `getURL` to ensure consistent URL formatting without trailing slashes.
- Updated all instances where URLs are constructed to use `process.env.NEXT_PUBLIC_REDIRECT_URL` and `${protocol}://${host}`


### Notes for Environment Changes
To ensure the new `getURL` function works correctly in production, make sure to set the following environment variables:

- `NEXT_PUBLIC_SITE_URL`: Set this to your production site URL (e.g., trypear.ai).
- `NEXT_PUBLIC_VERCEL_URL`: This is automatically set by Vercel.

**No trailing slashes should be included in these URLs to avoid issues with double slashes in paths.**

### Checklist

- [ ] I have tagged the issue in this PR.
- [ ] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
