### PR TITLE
Automate sign in from desktop pearai app

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -13,7 +13,10 @@ import {
 import { UpdatePasswordFormData } from "@/utils/form-schema";
 import { getURL } from "@/lib/utils";
 
-export async function signin(formData: FormData) {
+export async function signin(
+  formData: FormData,
+  callbackForDesktopApp: string,
+) {
   const supabase = createClient();
 
   const data: SignInWithPasswordCredentials = {
@@ -28,7 +31,9 @@ export async function signin(formData: FormData) {
   }
 
   revalidatePath("/", "layout");
-  redirect("/settings");
+  redirect(
+    `/settings${callbackForDesktopApp ? `?callback=${callbackForDesktopApp}` : ""}`,
+  );
 }
 
 // Flow: User signs up with email and password
@@ -78,12 +83,20 @@ export async function signup(formData: FormData) {
 }
 
 // OAuth sign-in with Google or GitHub
-export async function signinWithOAuth(provider: Provider) {
+export async function signinWithOAuth(
+  provider: Provider,
+  callbackForDesktopApp: string | string[] = "",
+) {
   const supabase = createClient();
+
+  const redirectToUrl = callbackForDesktopApp
+    ? `${getURL()}/auth/callback?callback=${callbackForDesktopApp}`
+    : `${getURL()}/auth/callback`;
+
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: provider,
     options: {
-      redirectTo: `${getURL()}/auth/callback`,
+      redirectTo: redirectToUrl,
     },
   });
 

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -92,9 +92,6 @@ export async function signinWithOAuth(provider: Provider) {
   }
 
   if (data.url) {
-    console.log("here");
-    console.log(data);
-    console.log(data.url);
     redirect(data.url);
   }
 

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -11,7 +11,6 @@ import {
   Session,
 } from "@supabase/supabase-js";
 import { UpdatePasswordFormData } from "@/utils/form-schema";
-import { headers } from "next/headers";
 import { getURL } from "@/lib/utils";
 
 export async function signin(formData: FormData) {
@@ -93,6 +92,9 @@ export async function signinWithOAuth(provider: Provider) {
   }
 
   if (data.url) {
+    console.log("here");
+    console.log(data);
+    console.log(data.url);
     redirect(data.url);
   }
 

--- a/app/(auth)/auth/callback/route.ts
+++ b/app/(auth)/auth/callback/route.ts
@@ -31,17 +31,19 @@ export async function GET(request: Request) {
       },
     );
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-    if (!error && data) {
-      if (callback) {
-        // redirect to desktop pearai app
+    if (!error) {
+      const response = NextResponse.redirect(`${origin}${next}`);
+      if (callback && data) {
+        // if login in from desktop app
         const accessToken = data.session.access_token;
         const refreshToken = data.session.refresh_token;
+        const encodedAccessToken = encodeURIComponent(accessToken);
+        const encodedRefreshToken = encodeURIComponent(refreshToken);
         return NextResponse.redirect(
-          `${callback}?accessToken=${accessToken}&refreshToken=${refreshToken}`,
+          `${origin}${next}?callback=${encodeURIComponent(callback)}&accessToken=${encodedAccessToken}&refreshToken=${encodedRefreshToken}`,
         );
-      } else {
-        return NextResponse.redirect(`${origin}${next}`);
       }
+      return response;
     }
     authError =
       error?.message ?? "Error during code exchange for oauth session";

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,12 +2,6 @@ import SettingsPage from "@/components/settings";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 
-export type PearAiDesktopAppCallback = {
-  callback: string;
-  accessToken: string;
-  refreshToken: string;
-};
-
 export default async function Settings() {
   const supabase = createClient();
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,7 +1,12 @@
-import { Button } from "@/components/ui/button";
+import SettingsPage from "@/components/settings";
 import { createClient } from "@/utils/supabase/server";
-import Link from "next/link";
 import { redirect } from "next/navigation";
+
+export type PearAiDesktopAppCallback = {
+  callback: string;
+  accessToken: string;
+  refreshToken: string;
+};
 
 export default async function Settings() {
   const supabase = createClient();
@@ -11,65 +16,5 @@ export default async function Settings() {
     redirect("/signin");
   }
 
-  return (
-    <section className="relative">
-      <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="pb-12 pt-32 md:pb-20 md:pt-40">
-          {/* Page header */}
-          <div className="mx-auto mb-12 max-w-3xl text-center md:mb-12">
-            <h1 className="text-4xl font-semibold md:text-5xl md:font-normal">
-              Settings
-            </h1>
-          </div>
-
-          {/* Settings */}
-          <div className="mx-auto mb-4 grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-2">
-            {/* Basic Info */}
-            <div className="rounded-md border p-4">
-              <h3 className="mb-3 text-2xl font-semibold">Basic Info</h3>
-              <div className="overflow-x-auto">
-                <table>
-                  <tbody className="text-sm">
-                    <tr>
-                      <td className="whitespace-nowrap pr-1">
-                        <span className="text-gray-500">Full Name:</span>{" "}
-                      </td>
-                      <td>{data.user.user_metadata.full_name}</td>
-                    </tr>
-                    <tr>
-                      <td className="whitespace-nowrap pr-1">
-                        <span className="text-gray-500">Email:</span>{" "}
-                      </td>
-                      <td>{data.user.email}</td>
-                    </tr>
-                  </tbody>
-                </table>
-                {data.user.app_metadata.provider === "email" && (
-                  <Button size="sm" className="mt-4">
-                    <Link href="/update-password">Update Password</Link>
-                  </Button>
-                )}
-              </div>
-            </div>
-
-            {/* Usage */}
-            <div className="flex flex-col rounded-md border p-3">
-              <h3 className="mb-3 text-2xl font-semibold">Usage</h3>
-
-              {/* Show only if the user already has a subscription */}
-              <p className="font-small">Coming soon</p>
-
-              {process.env.VERCEL_ENV !== "production" && (
-                <Button asChild size="sm" className="max-w-max">
-                  {/* Show only if the user does not have a subscription */}
-                  {/* TODO: Link to pricing page */}
-                  <Link href="/pricing">Upgrade to Pro</Link>
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+  return <SettingsPage user={data.user} />;
 }

--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -17,10 +17,14 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { SignInFormData, signInSchema } from "@/utils/form-schema";
+import { useSearchParams } from "next/navigation";
 
 export default function SignIn() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const callbackForDesktopApp = searchParams.get("callback") ?? "";
+
   const form = useForm<SignInFormData>({
     resolver: zodResolver(signInSchema),
     defaultValues: {
@@ -39,7 +43,7 @@ export default function SignIn() {
       formData.append("email", data.email);
       formData.append("password", data.password);
 
-      const response = await signin(formData);
+      const response = await signin(formData, callbackForDesktopApp);
       if (response?.error) {
         setErrorMessage(response.error);
       } else {
@@ -55,7 +59,7 @@ export default function SignIn() {
   const handleOAuthSignIn = async (provider: Provider) => {
     setErrorMessage(null);
     try {
-      await signinWithOAuth(provider);
+      await signinWithOAuth(provider, callbackForDesktopApp);
     } catch (error) {
       setErrorMessage("An unexpected error occurred. Please try again.");
     }

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -20,7 +20,9 @@ export default function SettingsPage({ user }: SettingsPageProps) {
     const refreshToken = searchParams.get("refreshToken");
 
     if (callback && accessToken && refreshToken) {
-      router.push(`${callback}/${accessToken}/${refreshToken}`);
+      router.push(
+        `${callback}?accessToken=${accessToken}&refreshToken=${refreshToken}`,
+      );
       // TODO: clear the tokens from query?
     } else if (callback) {
       // Alert user if callback is present but either accessToken or refreshToken is null

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { User } from "@supabase/supabase-js";
-import { Link } from "lucide-react";
-import { Button } from "./ui/button";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
@@ -74,17 +74,18 @@ export default function SettingsPage({ user }: SettingsPageProps) {
             {/* Usage */}
             <div className="flex flex-col rounded-md border p-3">
               <h3 className="mb-3 text-2xl font-semibold">Usage</h3>
+              <div className="flex h-full flex-col justify-between">
+                {/* Show only if the user already has a subscription */}
+                <p className="font-small">Coming soon</p>
 
-              {/* Show only if the user already has a subscription */}
-              <p className="font-small">Coming soon</p>
-
-              {process.env.VERCEL_ENV !== "production" && (
-                <Button asChild size="sm" className="max-w-max">
-                  {/* Show only if the user does not have a subscription */}
-                  {/* TODO: Link to pricing page */}
-                  <Link href="/pricing">Upgrade to Pro</Link>
-                </Button>
-              )}
+                {process.env.VERCEL_ENV !== "production" && (
+                  <Button asChild size="sm" className="mb-1 max-w-max">
+                    {/* Show only if the user does not have a subscription */}
+                    {/* TODO: Link to pricing page */}
+                    <Link href="/pricing">Upgrade to Pro</Link>
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -1,0 +1,94 @@
+"use client";
+import { User } from "@supabase/supabase-js";
+import { Link } from "lucide-react";
+import { Button } from "./ui/button";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+type SettingsPageProps = {
+  user: User;
+};
+
+export default function SettingsPage({ user }: SettingsPageProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    // Open pearai app on desktop
+    const callback = searchParams.get("callback");
+    const accessToken = searchParams.get("accessToken");
+    const refreshToken = searchParams.get("refreshToken");
+
+    if (callback && accessToken && refreshToken) {
+      router.push(`${callback}/${accessToken}/${refreshToken}`);
+      // TODO: clear the tokens from query?
+    } else if (callback) {
+      // Alert user if callback is present but either accessToken or refreshToken is null
+      alert(
+        "Access token or refresh token is missing. Cannot open PearAI app.",
+      );
+    }
+  }, [router, searchParams]);
+
+  return (
+    <section className="relative">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="pb-12 pt-32 md:pb-20 md:pt-40">
+          {/* Page header */}
+          <div className="mx-auto mb-12 max-w-3xl text-center md:mb-12">
+            <h1 className="text-4xl font-semibold md:text-5xl md:font-normal">
+              Settings
+            </h1>
+          </div>
+
+          {/* Settings */}
+          <div className="mx-auto mb-4 grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-2">
+            {/* Basic Info */}
+            <div className="rounded-md border p-4">
+              <h3 className="mb-3 text-2xl font-semibold">Basic Info</h3>
+              <div className="overflow-x-auto">
+                <table>
+                  <tbody className="text-sm">
+                    <tr>
+                      <td className="whitespace-nowrap pr-1">
+                        <span className="text-gray-500">Full Name:</span>{" "}
+                      </td>
+                      <td>{user.user_metadata.full_name}</td>
+                    </tr>
+                    <tr>
+                      <td className="whitespace-nowrap pr-1">
+                        <span className="text-gray-500">Email:</span>{" "}
+                      </td>
+                      <td>{user.email}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                {user.app_metadata.provider === "email" && (
+                  <Button size="sm" className="mt-4">
+                    <Link href="/update-password">Update Password</Link>
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            {/* Usage */}
+            <div className="flex flex-col rounded-md border p-3">
+              <h3 className="mb-3 text-2xl font-semibold">Usage</h3>
+
+              {/* Show only if the user already has a subscription */}
+              <p className="font-small">Coming soon</p>
+
+              {process.env.VERCEL_ENV !== "production" && (
+                <Button asChild size="sm" className="max-w-max">
+                  {/* Show only if the user does not have a subscription */}
+                  {/* TODO: Link to pricing page */}
+                  <Link href="/pricing">Upgrade to Pro</Link>
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Description

<!-- Provide a short description of the PR -->

Instead of having to copy and paste the API key to log in, this redirects the login back to the app with the access and refresh tokens if user signs in from app.

### Related Issue

<!-- Mention the issue number this PR addresses (e.g., #18) -->

### Changes Made

<!-- List the changes made in this PR -->

### Screenshots

<!-- Attach screenshots if any UI changes were made -->

### Checklist

- [x] I have tagged the issue in this PR.
- [ ] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
