### PR TITLE
Copy tokens to clipboard

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -74,3 +74,13 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .no-scrollbar {
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    scrollbar-width: none; /* Firefox */
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import Token from "@/components/settings/Token";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/server";
 import Link from "next/link";
@@ -50,19 +51,19 @@ export default async function Settings() {
                       </td>
                       <td className="break-all">{data.user.email}</td>
                     </tr>
-                    <tr>
-                      <td colSpan={2}>
-                        <p className="text-black-300 mb-1 break-all text-sm font-medium">
-                          PearAI Token: {sessionData.session.access_token}
-                        </p>
-                        <p className="text-black-300 mb-1 break-all text-sm font-medium">
-                          PearAI Refresh Token:{" "}
-                          {sessionData.session.refresh_token}
-                        </p>
-                      </td>
-                    </tr>
                   </tbody>
                 </table>
+
+                <div className="mt-4 space-y-3">
+                  <Token
+                    name="PearAI Token"
+                    value={sessionData.session.access_token}
+                  />
+                  <Token
+                    name="PearAI Refresh Token"
+                    value={sessionData.session.refresh_token}
+                  />
+                </div>
                 {data.user.app_metadata.provider === "email" && (
                   <Button size="sm" className="mt-4">
                     <Link href="/update-password">Update Password</Link>

--- a/components/settings/Token.tsx
+++ b/components/settings/Token.tsx
@@ -1,4 +1,7 @@
-import { CopyIcon } from "lucide-react";
+"use client";
+
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { CheckIcon, CopyIcon } from "lucide-react";
 import { FC } from "react";
 import { Button } from "../ui/button";
 
@@ -8,6 +11,8 @@ interface TokenProps {
 }
 
 const Token: FC<TokenProps> = ({ name, value }) => {
+  const { isCopied, copy } = useCopyToClipboard();
+
   return (
     <div className="text-sm">
       <p className="mb-0.5 font-medium">{name}:</p>
@@ -15,8 +20,8 @@ const Token: FC<TokenProps> = ({ name, value }) => {
         <div className="no-scrollbar h-7 w-full select-all overflow-x-auto whitespace-nowrap rounded-md border px-1.5 py-0.5">
           {value}
         </div>
-        <Button className="h-7 rounded-md px-1.5">
-          <CopyIcon size={16} />
+        <Button className="h-7 rounded-md px-1.5" onClick={() => copy(value)}>
+          {isCopied ? <CheckIcon size={16} /> : <CopyIcon size={16} />}
         </Button>
       </div>
     </div>

--- a/components/settings/Token.tsx
+++ b/components/settings/Token.tsx
@@ -1,0 +1,26 @@
+import { CopyIcon } from "lucide-react";
+import { FC } from "react";
+import { Button } from "../ui/button";
+
+interface TokenProps {
+  name: string;
+  value: string;
+}
+
+const Token: FC<TokenProps> = ({ name, value }) => {
+  return (
+    <div className="text-sm">
+      <p className="mb-0.5 font-medium">{name}:</p>
+      <div className="flex items-center gap-2">
+        <div className="no-scrollbar h-7 w-full select-all overflow-x-auto whitespace-nowrap rounded-md border px-1.5 py-0.5">
+          {value}
+        </div>
+        <Button className="h-7 rounded-md px-1.5">
+          <CopyIcon size={16} />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default Token;

--- a/hooks/useCopyToClipboard.ts
+++ b/hooks/useCopyToClipboard.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+
+type CopiedValue = string | null;
+
+type CopyFn = (text: string) => Promise<boolean>;
+
+export function useCopyToClipboard(): {
+  isCopied: boolean;
+  copiedText: CopiedValue;
+  copy: CopyFn;
+} {
+  const [copiedText, setCopiedText] = useState<CopiedValue>(null);
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copy: CopyFn = useCallback(async (text) => {
+    if (!navigator?.clipboard) {
+      console.warn("Clipboard not supported");
+      return false;
+    }
+
+    // Try to save to clipboard then save it in the state if worked
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedText(text);
+      setIsCopied(true);
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 3000);
+      return true;
+    } catch (error) {
+      console.warn("Copy failed", error);
+      setCopiedText(null);
+      return false;
+    }
+  }, []);
+
+  return { isCopied, copiedText, copy };
+}


### PR DESCRIPTION
### Description

This PR adds functionality to copy access and refresh tokens to the clipboard and updates the UI to support this new feature.

### Related Issue
Improves the UI for #123 

### Changes Made

- Updated the UI to include buttons for copying tokens to the clipboard
- Implemented clipboard copy functionality for access and refresh tokens

### Screenshots

![image](https://github.com/trypear/pear-landing-page/assets/64416825/0d11db74-6231-4e9a-b6bb-ce5c68452b29)
![image](https://github.com/trypear/pear-landing-page/assets/64416825/933fdd0d-e1b8-4a61-b560-3cb20e41fb2e)

### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
