### PR TITLE
Fix to use user instead of session

### DIFF
--- a/utils/withAuth.ts
+++ b/utils/withAuth.ts
@@ -10,16 +10,16 @@ export function withAuth(handler: AuthenticatedHandler) {
   return async (request: NextRequest) => {
     const supabase = createClient();
     const {
-      data: { session },
-    } = await supabase.auth.getSession();
+      data: { user },
+    } = await supabase.auth.getUser();
 
-    if (!session || !session.user) {
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     // add user to request object
     const authenticatedRequest = request as NextRequest & { user: User };
-    authenticatedRequest.user = session.user;
+    authenticatedRequest.user = user;
 
     return handler(authenticatedRequest);
   };


### PR DESCRIPTION
### Description

<!-- Provide a short description of the PR -->

Error we would get
```
"Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and many not be authentic. Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server."
```

### Related Issue

<!-- Mention the issue number this PR addresses (e.g., #18) -->

### Changes Made

<!-- List the changes made in this PR -->

### Screenshots

<!-- Attach screenshots if any UI changes were made -->

### Checklist

- [ ] I have tagged the issue in this PR.
- [ ] I have attached necessary screenshots.
- [ ] I have provided a short description of the PR.
- [ ] I ran `yarn build` and build is successful
- [ ] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
