### PR TITLE
remove next from redirectUrl. must change confirmation email template

### DIFF
--- a/app/(auth)/auth/confirm/route.ts
+++ b/app/(auth)/auth/confirm/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
   const token_hash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next") ?? "/settings";
-  const redirectUrl = searchParams.get("redirectUrl") ?? next;
+  const redirectUrl = searchParams.get("redirectUrl");
 
   const redirectTo = request.nextUrl.clone();
 


### PR DESCRIPTION
### Description
Currently users aren't redirected to the settings page when clicking the confirmation link in their email. This is because of a wrong email template setup.
This PR removes an attempted fix, since we can just change the email template to be correct.

Before
```html
<a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email&redirectUrl={{ .RedirectTo }}">
```
## Must Do @Fryingpannn 

Change [email template](https://supabase.com/dashboard/project/_/auth/templates) href to:
```html
<a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email">
```