### PR TITLE
Revamped Github Section of Landing Page

### DIFF
--- a/app/github/page.tsx
+++ b/app/github/page.tsx
@@ -3,15 +3,15 @@ import { constructMetadata } from "@/lib/utils";
 import { Metadata } from "next/types";
 
 export const metadata: Metadata = constructMetadata({
-    title: "GitHub",
-    description: "GitHub repositories PearAI",
-    canonical: "/github",
+  title: "GitHub",
+  description: "GitHub repositories PearAI",
+  canonical: "/github",
 });
 
 export default function github() {
-    return (
-        <>
-            <GithubPageComponent />
-        </>
-    );
+  return (
+    <>
+      <GithubPageComponent />
+    </>
+  );
 }

--- a/app/github/page.tsx
+++ b/app/github/page.tsx
@@ -1,0 +1,17 @@
+import GithubPageComponent from "@/components/github-page";
+import { constructMetadata } from "@/lib/utils";
+import { Metadata } from "next/types";
+
+export const metadata: Metadata = constructMetadata({
+    title: "GitHub",
+    description: "GitHub repositories PearAI",
+    canonical: "/github",
+});
+
+export default function github() {
+    return (
+        <>
+            <GithubPageComponent />
+        </>
+    );
+}

--- a/components/about.tsx
+++ b/components/about.tsx
@@ -152,5 +152,4 @@ const VideoCard: React.FC<VideoCardProps> = ({ src, title, description }) => (
     </CardContent>
   </Card>
 );
-
 export default AboutComponent;

--- a/components/github-page.tsx
+++ b/components/github-page.tsx
@@ -1,0 +1,223 @@
+import React from "react"
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { Card, CardContent, CardDescription } from "@/components/ui/card";
+const GithubPageComponent: React.FC = () => {
+    return (
+        <section
+            className="px-4 py-12 pt-20"
+            data-aos="fade-up"
+            data-aos-delay="200"
+        >
+            <div className="mx-auto max-w-6xl">
+                <div className="flex flex-col lg:flex-row">
+                    {/* Left column */}
+                    <div className="lg:w-1/2 lg:pr-8">
+
+                        <h2 className="mb-4 text-3xl font-bold">Github Repositories</h2>
+                        <div className="mb-8 text-gray-500">
+                            {/*App Repo */}
+                            <p>
+                                <a
+                                    href="https://github.com/trypear/pearai-app"
+                                    className="font-bold text-primary-700"
+                                >
+                                    PearAI App Github Repository
+                                </a>{" "}
+                                <span className="font-bold">(PLEASE STAR ⭐)</span>
+                            </p>
+                            <p>
+                                This is the main app for PearAI and contains the code for both
+                                the VSCode fork and AI chat extension (the submodule
+                                repository).
+                            </p>
+                            {/*App Repo Button*/}
+                            <div className="mt-6 w-full px-3 text-center lg:ml-10 lg:px-0 lg:text-left">
+                                <Button
+                                    asChild
+                                    size="lg"
+                                    variant="default"
+                                    className="h-12 w-3/4 text-xl text-white-main hover:bg-primary-800 hover:shadow-sm"
+                                >
+                                    <Link
+                                        href="https://github.com/trypear/pearai-app"
+                                        target="_blank"
+                                    >
+                                        App Repository
+                                        <ExternalLink size={"20"} />
+                                    </Link>
+                                </Button>
+                            </div>
+                            <br />
+
+                            {/*Submodule Repo */}
+                            <p>
+                                <a
+                                    href="https://github.com/trypear/pearai-submodule"
+                                    className="font-bold text-primary-700"
+                                >
+                                    PearAI Submodule Repository
+                                </a>{" "}
+                                <span className="font-bold">(PLEASE STAR ⭐)</span>
+                            </p>
+                            <p>
+                                The logic for all the AI related features including the chat. It
+                                is a submodule of the outer pearai-app repo because it is a fork
+                                of another open source repository.
+                            </p>
+                            {/*Submodule Repo Button*/}
+                            <div className="mt-6 w-full px-3 text-center lg:ml-10 lg:px-0 lg:text-left">
+                                <Button
+                                    asChild
+                                    size="lg"
+                                    variant="default"
+                                    className="h-12 w-3/4 text-xl text-white-main hover:bg-primary-800 hover:shadow-sm"
+                                >
+                                    <Link
+                                        href="https://github.com/trypear/pearai-submodule"
+                                        target="_blank"
+                                    >
+                                        Submodule Repository
+                                        <ExternalLink size={"20"} />
+                                    </Link>
+                                </Button>
+                            </div>
+                            <br />
+
+                            {/*Landing Page Repo */}
+                            <p>
+                                <a
+                                    href="https://github.com/trypear/pearai-landing-page"
+                                    className="font-bold text-primary-700"
+                                >
+                                    PearAI Landing Page Repository
+                                </a>
+
+                            </p>
+                            <p>
+                                This website which informs users about PearAI and its features.
+                                It includes the frontend implementation and user interface
+                                components.
+                            </p>
+                        </div>
+
+
+
+
+                        {/*Landing Page Repo Button*/}
+                        <div className="mt-6 w-full px-3 text-center lg:ml-10 lg:px-0 lg:text-left">
+                            <Button
+                                asChild
+                                size="lg"
+                                variant="default"
+                                className="h-12 w-3/4 text-xl text-white-main hover:bg-primary-800 hover:shadow-sm"
+                            >
+                                <Link
+                                    href="https://github.com/trypear/pear-landing-page"
+                                    target="_blank"
+                                >
+                                    Landing Page Repository
+                                    <ExternalLink size={"20"} />
+                                </Link>
+                            </Button>
+                        </div>
+
+
+                    </div>
+
+                    {/* Right column */}
+                    <div className="lg:w-1/2">
+                        <h2 className="mb-4 text-3xl font-bold">Quest Board</h2>
+                        <div className="mb-8 text-gray-500">
+                            <p>
+                                Checking out quest boards are a great way to get context on what’s currently being worked on.
+                                They can be found in the <a href="https://github.com/orgs/trypear/projects" className="font-bold text-primary-700">
+                                    Projects page
+                                </a> of the <a href="https://github.com/trypear" className="font-bold text-primary-700">
+                                    trypear github profile
+                                </a>.
+                            </p>
+                            <br></br>
+                            The three quest boards are:
+                            <li className="ml-2">
+                                <a href="https://github.com/orgs/trypear/projects/2" className="font-bold text-primary-700">
+                                    Landing Page Quest Board
+                                </a>
+                            </li>
+                            <li className="ml-2">
+                                <a href="https://github.com/orgs/trypear/projects/1" className="font-bold text-primary-700">
+                                    Backend & Server Quest Board
+                                </a>
+                            </li>
+                            <li className="ml-2">
+                                <a href="https://github.com/orgs/trypear/projects/5" className="font-bold text-primary-700">
+                                    Dev Experience & Testing Quest Board
+                                </a>
+                            </li>
+                            <br />
+                            <div
+                                className="font-bold rounded-3xl bg-primary-50 pb-3 pl-6 pr-6 pt-3 text-center text-primary-700"
+                                style={{
+                                    border: "1px solid rgba(20, 189, 149, 0.35)",
+                                    background: "rgba(20, 189, 149, 0.03)",
+                                }}
+                            >
+                                <p><a href="https://github.com/orgs/trypear/projects">Quest Boards</a></p>
+                            </div>
+                        </div>
+                        <div>
+                            <h2 className="mb-4 text-3xl font-bold ">Want to Contribute?</h2>
+                            <p>
+                                <a
+                                    href="https://docs.google.com/presentation/u/0/d/1zR9-7DTlb2PcsnapryZw8jHSkLTs9JxeXth4nyeemAQ/edit"
+                                    className="font-bold text-primary-700"
+                                >
+                                    pear.ai contributing 101
+                                </a>
+                            </p>
+
+
+                            {/* Contributing Guide + How are we going to work together (Squads)?  */}
+
+                            <p>
+                                <a
+                                    href="https://github.com/trypear/pearai-app/blob/main/CONTRIBUTING.md"
+                                    className="font-bold text-primary-700"
+                                >
+                                    Contributing Guide{" "}
+                                </a>
+                            </p>
+                            <p>
+                                <a
+                                    href="https://docs.google.com/document/d/1u_b6tN7rCCOBBSISaI_KMX7K2-vzJqgQIiJgMltegso/edit#heading=h.ns98wd85nc2o"
+                                    className="font-bold text-primary-700"
+                                >
+                                    {" "}
+                                    How are we going to work together (Squads)?
+                                </a>
+                            </p>
+
+                            {/* Explanation of Contributor Roles */}
+                            <p>
+                                <a
+                                    href="https://github.com/trypear/pearai-app/wiki/Open-Source-Roles"
+                                    className="font-bold text-primary-700"
+                                >
+                                    Explanation of Contributor Roles
+                                </a>
+                            </p>
+
+
+                            <br />
+
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default GithubPageComponent;

--- a/components/github-page.tsx
+++ b/components/github-page.tsx
@@ -1,223 +1,230 @@
-import React from "react"
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
-import { ExternalLink } from "lucide-react";
-import { Card, CardContent, CardDescription } from "@/components/ui/card";
+import React from "react";
 const GithubPageComponent: React.FC = () => {
-    return (
-        <section
-            className="px-4 py-12 pt-20"
-            data-aos="fade-up"
-            data-aos-delay="200"
-        >
-            <div className="mx-auto max-w-6xl">
-                <div className="flex flex-col lg:flex-row">
-                    {/* Left column */}
-                    <div className="lg:w-1/2 lg:pr-8">
+  return (
+    <section
+      className="px-4 py-12 pt-20"
+      data-aos="fade-up"
+      data-aos-delay="200"
+    >
+      <div className="mx-auto max-w-6xl">
+        <div className="flex flex-col lg:flex-row">
+          {/* Left column */}
+          <div className="lg:w-1/2 lg:pr-8">
+            <h2 className="mb-4 text-3xl font-bold">GitHub Repositories</h2>
+            <div className="mb-8 text-gray-500">
+              {/*App Repo */}
+              <p>
+                <a
+                  href="https://github.com/trypear/pearai-app"
+                  className="font-bold text-primary-700"
+                >
+                  PearAI App GitHub Repository
+                </a>{" "}
+                <span className="font-bold">(PLEASE STAR ⭐)</span>
+              </p>
+              <p>
+                This is the main app for PearAI and contains the code for both
+                the VSCode fork and AI chat extension (the submodule
+                repository).
+              </p>
+              <br />
 
-                        <h2 className="mb-4 text-3xl font-bold">Github Repositories</h2>
-                        <div className="mb-8 text-gray-500">
-                            {/*App Repo */}
-                            <p>
-                                <a
-                                    href="https://github.com/trypear/pearai-app"
-                                    className="font-bold text-primary-700"
-                                >
-                                    PearAI App Github Repository
-                                </a>{" "}
-                                <span className="font-bold">(PLEASE STAR ⭐)</span>
-                            </p>
-                            <p>
-                                This is the main app for PearAI and contains the code for both
-                                the VSCode fork and AI chat extension (the submodule
-                                repository).
-                            </p>
-                            {/*App Repo Button*/}
-                            <div className="mt-6 w-full px-3 text-center lg:ml-10 lg:px-0 lg:text-left">
-                                <Button
-                                    asChild
-                                    size="lg"
-                                    variant="default"
-                                    className="h-12 w-3/4 text-xl text-white-main hover:bg-primary-800 hover:shadow-sm"
-                                >
-                                    <Link
-                                        href="https://github.com/trypear/pearai-app"
-                                        target="_blank"
-                                    >
-                                        App Repository
-                                        <ExternalLink size={"20"} />
-                                    </Link>
-                                </Button>
-                            </div>
-                            <br />
+              {/*Submodule Repo */}
+              <p>
+                <a
+                  href="https://github.com/trypear/pearai-submodule"
+                  className="font-bold text-primary-700"
+                >
+                  PearAI Submodule Repository
+                </a>{" "}
+                <span className="font-bold">(PLEASE STAR ⭐)</span>
+              </p>
+              <p>
+                The logic for all the AI related features including the chat. It
+                is a submodule of the outer pearai-app repo because it is a fork
+                of another open source repository.
+              </p>
+              <br />
 
-                            {/*Submodule Repo */}
-                            <p>
-                                <a
-                                    href="https://github.com/trypear/pearai-submodule"
-                                    className="font-bold text-primary-700"
-                                >
-                                    PearAI Submodule Repository
-                                </a>{" "}
-                                <span className="font-bold">(PLEASE STAR ⭐)</span>
-                            </p>
-                            <p>
-                                The logic for all the AI related features including the chat. It
-                                is a submodule of the outer pearai-app repo because it is a fork
-                                of another open source repository.
-                            </p>
-                            {/*Submodule Repo Button*/}
-                            <div className="mt-6 w-full px-3 text-center lg:ml-10 lg:px-0 lg:text-left">
-                                <Button
-                                    asChild
-                                    size="lg"
-                                    variant="default"
-                                    className="h-12 w-3/4 text-xl text-white-main hover:bg-primary-800 hover:shadow-sm"
-                                >
-                                    <Link
-                                        href="https://github.com/trypear/pearai-submodule"
-                                        target="_blank"
-                                    >
-                                        Submodule Repository
-                                        <ExternalLink size={"20"} />
-                                    </Link>
-                                </Button>
-                            </div>
-                            <br />
-
-                            {/*Landing Page Repo */}
-                            <p>
-                                <a
-                                    href="https://github.com/trypear/pearai-landing-page"
-                                    className="font-bold text-primary-700"
-                                >
-                                    PearAI Landing Page Repository
-                                </a>
-
-                            </p>
-                            <p>
-                                This website which informs users about PearAI and its features.
-                                It includes the frontend implementation and user interface
-                                components.
-                            </p>
-                        </div>
-
-
-
-
-                        {/*Landing Page Repo Button*/}
-                        <div className="mt-6 w-full px-3 text-center lg:ml-10 lg:px-0 lg:text-left">
-                            <Button
-                                asChild
-                                size="lg"
-                                variant="default"
-                                className="h-12 w-3/4 text-xl text-white-main hover:bg-primary-800 hover:shadow-sm"
-                            >
-                                <Link
-                                    href="https://github.com/trypear/pear-landing-page"
-                                    target="_blank"
-                                >
-                                    Landing Page Repository
-                                    <ExternalLink size={"20"} />
-                                </Link>
-                            </Button>
-                        </div>
-
-
-                    </div>
-
-                    {/* Right column */}
-                    <div className="lg:w-1/2">
-                        <h2 className="mb-4 text-3xl font-bold">Quest Board</h2>
-                        <div className="mb-8 text-gray-500">
-                            <p>
-                                Checking out quest boards are a great way to get context on what’s currently being worked on.
-                                They can be found in the <a href="https://github.com/orgs/trypear/projects" className="font-bold text-primary-700">
-                                    Projects page
-                                </a> of the <a href="https://github.com/trypear" className="font-bold text-primary-700">
-                                    trypear github profile
-                                </a>.
-                            </p>
-                            <br></br>
-                            The three quest boards are:
-                            <li className="ml-2">
-                                <a href="https://github.com/orgs/trypear/projects/2" className="font-bold text-primary-700">
-                                    Landing Page Quest Board
-                                </a>
-                            </li>
-                            <li className="ml-2">
-                                <a href="https://github.com/orgs/trypear/projects/1" className="font-bold text-primary-700">
-                                    Backend & Server Quest Board
-                                </a>
-                            </li>
-                            <li className="ml-2">
-                                <a href="https://github.com/orgs/trypear/projects/5" className="font-bold text-primary-700">
-                                    Dev Experience & Testing Quest Board
-                                </a>
-                            </li>
-                            <br />
-                            <div
-                                className="font-bold rounded-3xl bg-primary-50 pb-3 pl-6 pr-6 pt-3 text-center text-primary-700"
-                                style={{
-                                    border: "1px solid rgba(20, 189, 149, 0.35)",
-                                    background: "rgba(20, 189, 149, 0.03)",
-                                }}
-                            >
-                                <p><a href="https://github.com/orgs/trypear/projects">Quest Boards</a></p>
-                            </div>
-                        </div>
-                        <div>
-                            <h2 className="mb-4 text-3xl font-bold ">Want to Contribute?</h2>
-                            <p>
-                                <a
-                                    href="https://docs.google.com/presentation/u/0/d/1zR9-7DTlb2PcsnapryZw8jHSkLTs9JxeXth4nyeemAQ/edit"
-                                    className="font-bold text-primary-700"
-                                >
-                                    pear.ai contributing 101
-                                </a>
-                            </p>
-
-
-                            {/* Contributing Guide + How are we going to work together (Squads)?  */}
-
-                            <p>
-                                <a
-                                    href="https://github.com/trypear/pearai-app/blob/main/CONTRIBUTING.md"
-                                    className="font-bold text-primary-700"
-                                >
-                                    Contributing Guide{" "}
-                                </a>
-                            </p>
-                            <p>
-                                <a
-                                    href="https://docs.google.com/document/d/1u_b6tN7rCCOBBSISaI_KMX7K2-vzJqgQIiJgMltegso/edit#heading=h.ns98wd85nc2o"
-                                    className="font-bold text-primary-700"
-                                >
-                                    {" "}
-                                    How are we going to work together (Squads)?
-                                </a>
-                            </p>
-
-                            {/* Explanation of Contributor Roles */}
-                            <p>
-                                <a
-                                    href="https://github.com/trypear/pearai-app/wiki/Open-Source-Roles"
-                                    className="font-bold text-primary-700"
-                                >
-                                    Explanation of Contributor Roles
-                                </a>
-                            </p>
-
-
-                            <br />
-
-                        </div>
-
-                    </div>
-                </div>
+              {/*Landing Page Repo */}
+              <p>
+                <a
+                  href="https://github.com/trypear/pearai-landing-page"
+                  className="font-bold text-primary-700"
+                >
+                  PearAI Landing Page Repository
+                </a>
+              </p>
+              <p>
+                This website which informs users about PearAI and its features.
+                It includes the frontend implementation and user interface
+                components.
+              </p>
             </div>
-        </section>
-    );
+            {/*App Repo Button*/}
+            <div className="m-4 mt-2 flex max-w-4xl flex-wrap items-center justify-center gap-4">
+              <div
+                className="rounded-3xl bg-primary-50 pb-3 pl-6 pr-6 pt-3 text-center font-bold text-primary-700"
+                style={{
+                  border: "1px solid rgba(20, 189, 149, 0.35)",
+                  background: "rgba(20, 189, 149, 0.03)",
+                }}
+              >
+                <p>
+                  <a href="https://github.com/trypear/pearai-app">
+                    app repo
+                  </a>
+                </p>
+              </div>
+              {/*Submodule Repo Button*/}
+              <div
+                className="rounded-3xl bg-primary-50 pb-3 pl-6 pr-6 pt-3 text-center font-bold text-primary-700"
+                style={{
+                  border: "1px solid rgba(20, 189, 149, 0.35)",
+                  background: "rgba(20, 189, 149, 0.03)",
+                }}
+              >
+                <p>
+                  <a href="https://github.com/trypear/pearai-submodule">
+                    submodule repo
+                  </a>
+                </p>
+              </div>
+              {/*Landing Page Repo Button*/}
+              <div
+                className="rounded-3xl bg-primary-50 pb-3 pl-6 pr-6 pt-3 text-center font-bold text-primary-700"
+                style={{
+                  border: "1px solid rgba(20, 189, 149, 0.35)",
+                  background: "rgba(20, 189, 149, 0.03)",
+                }}
+              >
+                <p>
+                  <a href="https://github.com/trypear/pearai-landing-page">
+                    landing page repo
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Right column */}
+          <div className="lg:w-1/2">
+            {/* Want to Contribute? */}
+            <div>
+              <h2 className="mb-4 text-3xl font-bold">Want to Contribute?</h2>
+              {/* PearAI Contributing 101 */}
+              <p>
+                <a
+                  href="https://docs.google.com/presentation/u/0/d/1zR9-7DTlb2PcsnapryZw8jHSkLTs9JxeXth4nyeemAQ/edit"
+                  className="font-bold text-primary-700"
+                >
+                  PearAI Contributing 101
+                </a>
+              </p>
+
+              {/* Contributing Guide */}
+              <p>
+                <a
+                  href="https://github.com/trypear/pearai-app/blob/main/CONTRIBUTING.md"
+                  className="font-bold text-primary-700"
+                >
+                  Contributing Guide{" "}
+                </a>
+              </p>
+              {/* How are we working together (Squads)? */}
+              <p>
+                <a
+                  href="https://docs.google.com/document/d/1u_b6tN7rCCOBBSISaI_KMX7K2-vzJqgQIiJgMltegso/edit#heading=h.ns98wd85nc2o"
+                  className="font-bold text-primary-700"
+                >
+                  {" "}
+                  How are we going to work together (Squads)?
+                </a>
+              </p>
+
+              {/* Explanation of Contributor Roles */}
+              <p>
+                <a
+                  href="https://github.com/trypear/pearai-app/wiki/Open-Source-Roles"
+                  className="font-bold text-primary-700"
+                >
+                  Explanation of Contributor Roles
+                </a>
+              </p>
+
+              <br />
+            </div>
+
+
+            {/* Quest Boards Section */}
+            <h2 className="mb-4 text-3xl font-bold">Quest Boards</h2>
+            <div className="mb-8 text-gray-500">
+              <p>
+                Checking out quest boards are a great way to get context on
+                what’s currently being worked on. They can be found in the{" "}
+                <a
+                  href="https://github.com/orgs/trypear/projects"
+                  className="font-bold text-primary-700"
+                >
+                  Projects page
+                </a>{" "}
+                of the{" "}
+                <a
+                  href="https://github.com/trypear"
+                  className="font-bold text-primary-700"
+                >
+                  trypear GitHub profile
+                </a>
+                .
+              </p>
+              <br></br>
+              The three quest boards are:
+              <li className="ml-2">
+                <a
+                  href="https://github.com/orgs/trypear/projects/2"
+                  className="font-bold text-primary-700"
+                >
+                  Landing Page Quest Board
+                </a>
+              </li>
+              <li className="ml-2">
+                <a
+                  href="https://github.com/orgs/trypear/projects/1"
+                  className="font-bold text-primary-700"
+                >
+                  Backend & Server Quest Board
+                </a>
+              </li>
+              <li className="ml-2">
+                <a
+                  href="https://github.com/orgs/trypear/projects/5"
+                  className="font-bold text-primary-700"
+                >
+                  Dev Experience & Testing Quest Board
+                </a>
+              </li>
+              <br />
+              {/*Quest Boards Button */}
+              <div
+                className="rounded-3xl bg-primary-50 pb-3 pl-6 pr-6 pt-3 text-center font-bold text-primary-700"
+                style={{
+                  border: "1px solid rgba(20, 189, 149, 0.35)",
+                  background: "rgba(20, 189, 149, 0.03)",
+                }}
+              >
+                <p>
+                  <a href="https://github.com/orgs/trypear/projects">
+                    Quest Boards
+                  </a>
+                </p>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default GithubPageComponent;

--- a/components/github-page.tsx
+++ b/components/github-page.tsx
@@ -71,9 +71,7 @@ const GithubPageComponent: React.FC = () => {
                 }}
               >
                 <p>
-                  <a href="https://github.com/trypear/pearai-app">
-                    app repo
-                  </a>
+                  <a href="https://github.com/trypear/pearai-app">app repo</a>
                 </p>
               </div>
               {/*Submodule Repo Button*/}
@@ -155,7 +153,6 @@ const GithubPageComponent: React.FC = () => {
               <br />
             </div>
 
-
             {/* Quest Boards Section */}
             <h2 className="mb-4 text-3xl font-bold">Quest Boards</h2>
             <div className="mb-8 text-gray-500">
@@ -218,7 +215,6 @@ const GithubPageComponent: React.FC = () => {
                   </a>
                 </p>
               </div>
-
             </div>
           </div>
         </div>

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -12,8 +12,8 @@ export default async function Header() {
     { label: "About", path: "/about", isExternal: false },
     {
       label: "GitHub",
-      path: "https://github.com/trypear/pearai-app",
-      isExternal: true,
+      path: "/github",
+      isExternal: false,
     },
     {
       label: "Discord",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,7 +28,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz"
   integrity sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.0.0-0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.12.0", "@babel/core@^7.13.0", "@babel/core@^7.21.3", "@babel/core@^7.4.0 || ^8.0.0-0 <8.0.0":
+"@babel/core@^7.21.3":
   version "7.24.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz"
   integrity sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==
@@ -1189,6 +1189,46 @@
   dependencies:
     glob "10.3.10"
 
+"@next/swc-darwin-arm64@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz#d0a160cf78c18731c51cc0bff131c706b3e9bb05"
+  integrity sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==
+
+"@next/swc-darwin-x64@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz#eb832a992407f6e6352eed05a073379f1ce0589c"
+  integrity sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==
+
+"@next/swc-linux-arm64-gnu@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz#098fdab57a4664969bc905f5801ef5a89582c689"
+  integrity sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==
+
+"@next/swc-linux-arm64-musl@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz#243a1cc1087fb75481726dd289c7b219fa01f2b5"
+  integrity sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==
+
+"@next/swc-linux-x64-gnu@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz#b8a2e436387ee4a52aa9719b718992e0330c4953"
+  integrity sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==
+
+"@next/swc-linux-x64-musl@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz#cb8a9adad5fb8df86112cfbd363aab5c6d32757b"
+  integrity sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==
+
+"@next/swc-win32-arm64-msvc@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz#81f996c1c38ea0900d4e7719cc8814be8a835da0"
+  integrity sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==
+
+"@next/swc-win32-ia32-msvc@14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz#f61c74ce823e10b2bc150e648fc192a7056422e0"
+  integrity sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==
+
 "@next/swc-win32-x64-msvc@14.2.5":
   version "14.2.5"
   resolved "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz"
@@ -1202,7 +1242,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1273,7 +1313,7 @@
 
 "@radix-ui/react-checkbox@^1.1.1":
   version "1.1.1"
-  resolved "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.1.1.tgz#a559c4303957d797acee99914480b755aa1f27d6"
   integrity sha512-0i/EKJ222Afa1FE0C6pNJxDq1itzcl3HChE9DwskA4th4KRse8ojx8a1nVcOjwJdbpDLcz7uol77yYnQNMHdKw==
   dependencies:
     "@radix-ui/primitive" "1.1.0"
@@ -1305,7 +1345,7 @@
   resolved "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz"
   integrity sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==
 
-"@radix-ui/react-dialog@^1.0.5", "@radix-ui/react-dialog@1.1.1":
+"@radix-ui/react-dialog@1.1.1", "@radix-ui/react-dialog@^1.0.5":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz"
   integrity sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==
@@ -1525,7 +1565,7 @@
     "@radix-ui/react-use-previous" "1.1.0"
     "@radix-ui/react-use-size" "1.1.0"
 
-"@radix-ui/react-slot@^1.1.0", "@radix-ui/react-slot@1.1.0":
+"@radix-ui/react-slot@1.1.0", "@radix-ui/react-slot@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz"
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
@@ -1637,7 +1677,7 @@
   dependencies:
     "@supabase/node-fetch" "^2.6.14"
 
-"@supabase/node-fetch@^2.6.14", "@supabase/node-fetch@2.6.15":
+"@supabase/node-fetch@2.6.15", "@supabase/node-fetch@^2.6.14":
   version "2.6.15"
   resolved "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz"
   integrity sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==
@@ -1676,7 +1716,7 @@
   dependencies:
     "@supabase/node-fetch" "^2.6.14"
 
-"@supabase/supabase-js@^2.33.1", "@supabase/supabase-js@^2.43.4":
+"@supabase/supabase-js@^2.43.4":
   version "2.43.4"
   resolved "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.43.4.tgz"
   integrity sha512-/pLPaxiIsn5Vaz3s32HC6O/VNwfeddnzS0bZRpOW0AKcPuXroD8pT9G8mpiBlZfpKsMmq6k7tlhW7Sr1PAQ1lw==
@@ -1742,7 +1782,7 @@
     "@svgr/babel-plugin-transform-react-native-svg" "8.1.0"
     "@svgr/babel-plugin-transform-svg-component" "8.0.0"
 
-"@svgr/core@*", "@svgr/core@8.1.0":
+"@svgr/core@8.1.0":
   version "8.1.0"
   resolved "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz"
   integrity sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==
@@ -1846,16 +1886,16 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz"
   integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==
 
-"@types/react-dom@*", "@types/react-dom@^18.3.0":
+"@types/react-dom@^18.2.17":
   version "18.3.0"
-  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.8.0 || ^17.0.0 || ^18.0.0", "@types/react@^16.9.0 || ^17.0.0 || ^18.0.0", "@types/react@^18.3.3":
+"@types/react@*", "@types/react@^18.2.42":
   version "18.3.3"
-  resolved "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
   integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
   dependencies:
     "@types/prop-types" "*"
@@ -1936,7 +1976,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.9.0:
+acorn@^8.9.0:
   version "8.12.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz"
   integrity sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==
@@ -1968,14 +2008,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  dependencies:
-    color-convert "^2.0.1"
-
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -2234,7 +2267,7 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.21.10, browserslist@^4.22.2, browserslist@^4.23.0, "browserslist@>= 4.21.0":
+browserslist@^4.21.10, browserslist@^4.22.2, browserslist@^4.23.0:
   version "4.23.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz"
   integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
@@ -2326,20 +2359,20 @@ classlist-polyfill@^1.2.0:
   resolved "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz"
   integrity sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ==
 
-client-only@^0.0.1, client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
-
-clsx@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
-  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 clsx@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz"
   integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
+
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -2355,15 +2388,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 commander@^4.0.0:
   version "4.1.1"
@@ -2838,7 +2871,7 @@ eslint-config-next@14.2.4:
     eslint-plugin-react "^7.33.2"
     eslint-plugin-react-hooks "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
 
-eslint-config-prettier@*, eslint-config-prettier@^9.1.0:
+eslint-config-prettier@^9.1.0:
   version "9.1.0"
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz"
   integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
@@ -2872,7 +2905,7 @@ eslint-module-utils@^2.7.4, eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@*, eslint-plugin-import@^2.28.1:
+eslint-plugin-import@^2.28.1:
   version "2.29.1"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz"
   integrity sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==
@@ -2967,7 +3000,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.23.0 || ^8.0.0", eslint@^8, eslint@^8.56.0, eslint@>=7.0.0, eslint@>=8.0.0:
+eslint@^8:
   version "8.57.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz"
   integrity sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==
@@ -3148,6 +3181,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -3205,7 +3243,7 @@ get-tsconfig@^4.5.0:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -3219,25 +3257,6 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
-
-glob@^7.1.3, glob@7.1.6:
-  version "7.1.6"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@10.3.10:
   version "10.3.10"
   resolved "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz"
@@ -3248,6 +3267,18 @@ glob@10.3.10:
     minimatch "^9.0.1"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
+
+glob@7.1.6, glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -3813,6 +3844,13 @@ mini-svg-data-uri@^1.2.3:
   resolved "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz"
   integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
 
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -3827,13 +3865,6 @@ minimatch@^9.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
@@ -3844,7 +3875,7 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
-ms@^2.1.1, ms@2.1.2:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -3873,7 +3904,7 @@ next-themes@^0.3.0:
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz"
   integrity sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==
 
-next@^14.2.5, "next@>= 13":
+next@^14.2.5:
   version "14.2.5"
   resolved "https://registry.npmjs.org/next/-/next-14.2.5.tgz"
   integrity sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==
@@ -4162,21 +4193,21 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.0.0, postcss@^8.1.0, postcss@^8.2.14, postcss@^8.4.21, postcss@^8.4.23, postcss@^8.4.32, postcss@>=8.0.9:
-  version "8.4.32"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz"
-  integrity sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 postcss@8.4.31:
   version "8.4.31"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
   integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
     nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.23, postcss@^8.4.32:
+  version "8.4.32"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz"
+  integrity sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==
+  dependencies:
+    nanoid "^3.3.7"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -4211,7 +4242,7 @@ prettier-plugin-tailwindcss@^0.6.3:
   resolved "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.5.tgz"
   integrity sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==
 
-prettier@^3.0, prettier@^3.3.2, prettier@>=3.0.0:
+prettier@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz"
   integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
@@ -4240,7 +4271,7 @@ ramda@^0.29.0:
   resolved "https://registry.npmjs.org/ramda/-/ramda-0.29.1.tgz"
   integrity sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==
 
-"react-dom@^16 || ^17 || ^18", "react-dom@^16.8 || ^17 || ^18", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", react-dom@^18.0.0, react-dom@^18.2.0, react-dom@>=16.8.0, react-dom@18.2.0:
+react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -4248,7 +4279,7 @@ ramda@^0.29.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-hook-form@^7.0.0, react-hook-form@^7.52.0:
+react-hook-form@^7.52.0:
   version "7.52.1"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.1.tgz"
   integrity sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==
@@ -4291,7 +4322,7 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-"react@^16 || ^17 || ^18", "react@^16.5.1 || ^17.0.0 || ^18.0.0", "react@^16.8 || ^17 || ^18", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^18 || ^19", react@^18.0.0, react@^18.2.0, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", react@>=16.8.0, react@18.2.0:
+react@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -4739,7 +4770,7 @@ tailwindcss-animate@^1.0.7:
   resolved "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz"
   integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
 
-tailwindcss@^3.3.6, "tailwindcss@>=3.0.0 || >= 3.0.0-alpha.1", "tailwindcss@>=3.0.0 || insiders":
+tailwindcss@^3.3.6:
   version "3.3.6"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.6.tgz"
   integrity sha512-AKjF7qbbLvLaPieoKeTjG1+FyNZT6KaJMJPFeQyLfIp7l82ggH1fbHJSsYIvnbTFQOlkh+gBYpyby5GT1LIdLw==
@@ -4889,7 +4920,7 @@ typed-array-length@^1.0.6:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
 
-typescript@^5.5.3, typescript@>=3.3.1, typescript@>=4.2.0, typescript@>=4.9.5:
+typescript@^5.5.3:
   version "5.5.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz"
   integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==


### PR DESCRIPTION
### Description

Currently, clicking 'GitHub' on the navbar of the landing page leads to the main app github repository. I implemented a whole page containing info and links to the 3 PearAI repositories - the app repo, submodule repo, and landing page repo. I've also added a bit of additional information such as relevant contribution links and an explanation of and links related to the 3 quest boards.

### Related Issue

I made this page in order to address "Revamping Github section of Landing Page https://github.com/trypear/pear-landing-page/issues/169".


### Screenshots

<img width="1710" alt="Screenshot 2024-07-19 at 4 58 35 PM" src="https://github.com/user-attachments/assets/e7d78d97-0937-4c15-b045-1097ecc0f613">

<img width="1710" alt="Screenshot 2024-07-19 at 4 58 46 PM" src="https://github.com/user-attachments/assets/8e1a19a3-8760-4b2e-b2bf-f61d88e700a4">


### Checklist
 
- [X] I have tagged the issue in this PR.
- [X] I have attached necessary screenshots.
- [X] I have provided a short description of the PR.
- [X] I ran yarn build and build is successful
- [X] My code follows the style guidelines of this project.
- [X] I have added necessary documentation (if applicable)
