### PR TITLE
Fix mobile responsive UI issue and dark mode color issue

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -108,7 +108,7 @@
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
 
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 62.8% 40.6%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 217.2 32.6% 17.5%;

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -90,7 +90,7 @@ function SingleFeature(props: SingleFeatureProps) {
           {props.info.description}
         </div>
       </div>
-      <div className="w-[290px] min-[375px]:w-[350px] md:w-[600px] lg:w-[800px]">
+      <div className="w-full lg:w-[800px]">
         <AspectRatio ratio={3 / 2}>
           <video
             autoPlay

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -93,7 +93,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(error && "text-black", className)}
+      className={cn(className)}
       htmlFor={formItemId}
       {...props}
     />


### PR DESCRIPTION
### Description

This PR fixes the mobile responsive issue on the landing page. Additionally, it corrects the color mismatch of input labels and error messages in dark mode.

### Related Issue

<!-- Mention the issue number this PR addresses (e.g., #18) -->

### Changes Made

- Adjusted the CSS to ensure elements are properly scaled on smaller screens.
- Fixed the color of input labels in dark mode when there is an error.
- Corrected the color of error messages in dark mode.

### Screenshots


Before (Uneven horizontal padding):
![Screenshot 2024-07-20 at 9 27 24 AM](https://github.com/user-attachments/assets/cd844311-2a99-455d-ad6d-6f51793499b9)

After (Even horizontal padding):
![Screenshot 2024-07-20 at 9 26 49 AM](https://github.com/user-attachments/assets/68f1935c-87e0-42b1-baeb-f6641aa87936)


Before:
![Screenshot 2024-07-20 at 9 28 52 AM](https://github.com/user-attachments/assets/b60ecb9d-ad17-4bbb-9d27-4cba51bf09c3)

After:
![Screenshot 2024-07-20 at 9 29 15 AM](https://github.com/user-attachments/assets/671d6a43-fc3a-4b32-bb62-54264423c320)

### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
