### PR TITLE
fix - typo in settings

### DIFF
--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -234,7 +234,8 @@ export default function SettingsPage({
                         <strong>Current period: </strong>
                         {new Date(
                           subscription.current_period_start * 1000,
-                        ).toLocaleDateString()}
+                        ).toLocaleDateString()}{" "}
+                        -{" "}
                         {subscription.current_period_end
                           ? new Date(
                               subscription.current_period_end * 1000,


### PR DESCRIPTION
**Before:**
<img width="265" alt="Screenshot 2024-07-29 at 10 40 11 PM" src="https://github.com/user-attachments/assets/f684aecf-7576-48f6-ab0a-f55186e029d7">

**After:**
<img width="280" alt="Screenshot 2024-07-29 at 10 40 25 PM" src="https://github.com/user-attachments/assets/9a268dd7-652d-47e6-9519-35a21f778395">
