### PR TITLE
fix: remove "next/head" from app directory

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,11 +1,14 @@
-import Head from "next/head";
+import { constructMetadata } from "@/lib/utils";
+import { Metadata } from "next";
 
+export const metadata: Metadata = constructMetadata({
+  title: "Page Not Found",
+  description: "The requested page could not be found.",
+  canonical: "/404",
+});
 export default function Custom404() {
   return (
     <>
-      <Head>
-        <title>404 - Page Not Found</title>
-      </Head>
       <section className="relative">
         <div className="mx-auto max-w-6xl px-4 sm:px-6">
           <div className="pb-12 pt-32 md:pb-20 md:pt-20">


### PR DESCRIPTION
### Description
fixes warning: "Warning: You're using `next/head` inside the `app` directory, please migrate to the Metadata API. See https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-3-migrating-nexthead for more details."
<!-- Provide a short description of the PR -->

### Related Issue

<!-- Mention the issue number this PR addresses (e.g., #18) -->

### Changes Made

<!-- List the changes made in this PR -->

### Screenshots
![image](https://github.com/user-attachments/assets/39e76c44-93e7-4d28-b27a-493ba24f578a)

<!-- Attach screenshots if any UI changes were made -->

### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
