### PR TITLE
Email contact improvements

### DIFF
--- a/components/pricing-success.tsx
+++ b/components/pricing-success.tsx
@@ -2,7 +2,8 @@
 
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
-import { useSearchParams } from "next/navigation";
+import { CONTACT_EMAIL } from "@/utils/constants";
+import Link from "next/link";
 
 export default function PricingSuccess() {
   const router = useRouter();
@@ -29,7 +30,14 @@ export default function PricingSuccess() {
               ></div>
               <div className="text-center text-gray-700">
                 We hope you enjoy using Pear. Feel free to send any suggestions
-                our way at pear@trypear.ai.
+                our way at{" "}
+                <Link
+                  href={`mailto:{CONTACT_EMAIL}`}
+                  className="font-medium text-gray-900 underline"
+                >
+                  {CONTACT_EMAIL}
+                </Link>
+                .
               </div>
               <div
                 className="ml-3 grow border-t border-dotted border-gray-700"

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Check, Download } from "lucide-react";
 import Link from "next/link";
 import { useCheckout } from "@/hooks/useCheckout";
-import { PRICING_TIERS } from "@/utils/constants";
+import { PRICING_TIERS, CONTACT_EMAIL } from "@/utils/constants";
 import { PricingPageProps, PricingTierProps } from "@/types/pricing";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -271,13 +271,16 @@ const PricingPage: React.FC<PricingPageProps> = ({ user }) => {
           <div className="text-center">
             <p className="text-base text-gray-400 sm:text-lg md:text-xl">
               Want to use Pear in your business?
-              <Link
-                href="mailto:pear@trypear.ai"
-                className="ml-2 font-semibold text-primary-700 hover:text-primary-800"
+              <button
+                className="ml-2 font-semibold text-primary-700 transition-colors hover:text-primary-800"
                 aria-label="Contact us for custom plans"
+                onClick={() => {
+                  navigator.clipboard.writeText(CONTACT_EMAIL);
+                  toast.success("Email copied to clipboard!");
+                }}
               >
                 Contact us for custom plans!
-              </Link>
+              </button>
             </p>
           </div>
         </div>

--- a/components/privacy-policy.tsx
+++ b/components/privacy-policy.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { CONTACT_EMAIL } from "@/utils/constants";
+
 export default function PrivacyPolicyComponent() {
   return (
     <section>
@@ -711,13 +713,27 @@ export default function PrivacyPolicyComponent() {
                 If you have any questions about this Privacy Policy or our
                 privacy and security practices or you wish to make a complaint
                 about our compliance with applicable privacy laws, please feel
-                free to contact us at pear@trypear.ai.
+                free to contact us at{" "}
+                <Link
+                  href={`mailto:${CONTACT_EMAIL}`}
+                  className="font-medium text-gray-900 underline"
+                >
+                  {CONTACT_EMAIL}
+                </Link>
+                .
               </p>
               <p>
                 If you have questions or concerns about the way we are handling
                 your personal information, or would like to exercise your
                 privacy rights, please email us with the subject line
-                &quot;Privacy Concern&quot; at pear@trypear.ai.
+                &quot;Privacy Concern&quot; at{" "}
+                <Link
+                  href={`mailto:${CONTACT_EMAIL}`}
+                  className="font-medium text-gray-900 underline"
+                >
+                  {CONTACT_EMAIL}
+                </Link>
+                .
               </p>
               <p>
                 In most cases, we will respond within 30 days of receiving your

--- a/components/terms-of-service.tsx
+++ b/components/terms-of-service.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { CONTACT_EMAIL } from "@/utils/constants";
 
 export default function TermsOfServiceComponent() {
   return (
@@ -130,10 +131,10 @@ export default function TermsOfServiceComponent() {
                   your account is no longer secure, then you should immediately
                   notify us at&nbsp;
                   <Link
-                    href="mailto:pear@trypear.ai"
+                    href={`mailto:${CONTACT_EMAIL}`}
                     className="font-medium text-gray-900 underline"
                   >
-                    pear@trypear.ai
+                    {CONTACT_EMAIL}
                   </Link>
                   .
                 </li>
@@ -275,10 +276,10 @@ export default function TermsOfServiceComponent() {
                         by using the cancellation functionality made available
                         in your billing menu or by contacting us at&nbsp;
                         <Link
-                          href="mailto:pear@trypear.ai"
+                          href={`mailto:${CONTACT_EMAIL}`}
                           className="font-medium text-gray-900 underline"
                         >
-                          pear@trypear.ai
+                          {CONTACT_EMAIL}
                         </Link>
                         . YOUR CANCELLATION MUST BE RECEIVED BEFORE THE RENEWAL
                         DATE IN ORDER TO AVOID CHARGE FOR THE NEXT SUBSCRIPTION
@@ -730,10 +731,10 @@ export default function TermsOfServiceComponent() {
                         be resolved quickly and to the customer’s satisfaction
                         by emailing customer support at&nbsp;
                         <Link
-                          href="mailto:pear@trypear.ai"
+                          href={`mailto:${CONTACT_EMAIL}`}
                           className="font-medium text-gray-900 underline"
                         >
-                          pear@trypear.ai
+                          {CONTACT_EMAIL}
                         </Link>
                         . If such efforts prove unsuccessful, a party who
                         intends to seek arbitration must first send to the
@@ -1019,10 +1020,10 @@ export default function TermsOfServiceComponent() {
                         us by sending correspondence to that address or by
                         emailing us at&nbsp;
                         <Link
-                          href="mailto:pear@trypear.ai"
+                          href={`mailto:${CONTACT_EMAIL}`}
                           className="font-medium text-gray-900 underline"
                         >
-                          pear@trypear.ai
+                          {CONTACT_EMAIL}
                         </Link>
                         .
                       </p>

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -4,6 +4,8 @@ export const TEST_MODE_ENABLED = ["true", "True", "TRUE"].includes(
   process.env.NEXT_PUBLIC_TEST_MODE_ENABLED ?? "",
 );
 
+export const CONTACT_EMAIL = "pear@trypear.ai";
+
 const NEXT_PUBLIC_STRIPE_WAITLIST_PRICE_ID = "price_1PZ9X608N4O93LU5yqMbGDtu";
 const NEXT_PUBLIC_STRIPE_WAITLIST_PRICE_ID_TEST =
   "price_1PZUT208N4O93LU5jItKoEYu";


### PR DESCRIPTION
### Description
Improve how contact email is handled in the repo

### Related Issue

No related issue. I just really hate clicking on email links and it opening the default Mac mail app, or the default iOS mail app. This is much better, people can copy and then paste into Gmail web/whatever they want

### Changes Made
- Contact link on pricing page now copies `pear@trypear.ai` to clipboard
- CONTACT_EMAIL is now a value in constants
- Email links in privacy policy and TOS are consistent

### Screenshots

![image](https://github.com/user-attachments/assets/4c8eec2f-3556-46a6-a78c-7f13abb52587)

### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
