### PR TITLE
Spelling mistake on FAQ page

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -56,7 +56,7 @@ const FAQ: React.FC = () => {
           ))}
           <AccordionItem value={"contribute"}>
             <AccordionTrigger className="text-left font-semibold">
-              How can I contribute to PearAI
+              How can I contribute to PearAI?
             </AccordionTrigger>
             <AccordionContent className="text-base text-gray-600">
               See the contributor&apos;s section.{" "}


### PR DESCRIPTION
### Description

This should have a ?
![image](https://github.com/user-attachments/assets/9c66499f-9041-40c3-ab85-586436a8838e)

### Related Issue

None

### Changes Made

Just added a ? to the last FAQ question

### Screenshots

![image](https://github.com/user-attachments/assets/9c66499f-9041-40c3-ab85-586436a8838e)

### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
