### PR TITLE
Added disclaimer to "Open PearAI" button

### DIFF
--- a/components/dashboard/freetrial-card.tsx
+++ b/components/dashboard/freetrial-card.tsx
@@ -3,6 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import { Info } from 'lucide-react';
 
 type FreeTrialCardProps = {
   usage: {
@@ -68,6 +69,10 @@ export default function FreeTrialCard({
                   Open PearAI
                 </Link>
               </Button>
+              <div className="mt-5 flex items-center">
+                <Info className="inline text-muted-foreground" size={16} />
+                <p className="ml-1 block text-sm text-muted-foreground">Make sure PearAI is installed</p>
+              </div>
             </div>
             <Button variant="link" asChild className="px-0 text-primary-800">
               <Link href="/pricing">Subscribe Now</Link>

--- a/components/dashboard/freetrial-card.tsx
+++ b/components/dashboard/freetrial-card.tsx
@@ -78,8 +78,9 @@ export default function FreeTrialCard({
                     asChild
                     className="p-0 text-xs text-primary-800"
                   >
-                    <Link href="/pricing">installed</Link>
-                  </Button>
+                    <Link href="/pricing">installed.</Link>
+                  </Button>{" "}
+                  Use this button to open the app and login directly.
                 </p>
               </div>
             </div>

--- a/components/dashboard/freetrial-card.tsx
+++ b/components/dashboard/freetrial-card.tsx
@@ -69,9 +69,9 @@ export default function FreeTrialCard({
                   Open PearAI
                 </Link>
               </Button>
-              <div className="mt-5 flex items-center">
-                <Info className="inline text-muted-foreground" size={16} />
-                <p className="ml-1 block text-sm text-muted-foreground">Make sure PearAI is installed</p>
+              <div className="mt-1 flex items-center">
+                <Info className="inline text-muted-foreground" size={14} />
+                <p className="ml-1.5 block text-xs text-muted-foreground">Make sure PearAI is <Button variant='link' asChild className="p-0 text-primary-800 text-xs"><Link href='/pricing'>installed</Link></Button></p>
               </div>
             </div>
             <Button variant="link" asChild className="px-0 text-primary-800">

--- a/components/dashboard/freetrial-card.tsx
+++ b/components/dashboard/freetrial-card.tsx
@@ -3,7 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
-import { Info } from 'lucide-react';
+import { Info } from "lucide-react";
 
 type FreeTrialCardProps = {
   usage: {
@@ -71,7 +71,16 @@ export default function FreeTrialCard({
               </Button>
               <div className="mt-1 flex items-center">
                 <Info className="inline text-muted-foreground" size={14} />
-                <p className="ml-1.5 block text-xs text-muted-foreground">Make sure PearAI is <Button variant='link' asChild className="p-0 text-primary-800 text-xs"><Link href='/pricing'>installed</Link></Button></p>
+                <p className="ml-1.5 block text-xs text-muted-foreground">
+                  Make sure PearAI is{" "}
+                  <Button
+                    variant="link"
+                    asChild
+                    className="p-0 text-xs text-primary-800"
+                  >
+                    <Link href="/pricing">installed</Link>
+                  </Button>
+                </p>
               </div>
             </div>
             <Button variant="link" asChild className="px-0 text-primary-800">


### PR DESCRIPTION
### Description

Currently, there is no disclaimer to indicate that the PearAI app must be installed for the "Open PearAI" button in the Subscription card to work. This can be confusing, so I added a small disclaimer containing a small explanation and a hyperlink to the pricing page.

### Related Issue
#218 

### Changes Made

- Added disclaimer to "Open PearAI" button in the Subscription card on the Dashboard page

### Screenshots
Before
![image](https://github.com/user-attachments/assets/0755e846-2412-4f97-b534-d19277a20637)

After
![image](https://github.com/user-attachments/assets/8779ddd8-dfe5-400d-a3d3-137ce9a97e32)


### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)

