### PR TITLE
Oauth form fix

### DIFF
--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -76,10 +76,12 @@ export default function SignIn() {
           </div>
 
           <div className="mx-auto max-w-sm">
-            <form onSubmit={(e) => {
-              e.preventDefault();
-              handleOAuthSignIn("google");
-              }}>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleOAuthSignIn("google");
+              }}
+            >
               <Button
                 type="submit"
                 size="lg"
@@ -90,10 +92,12 @@ export default function SignIn() {
                 <span className="">Sign in with Google</span>
               </Button>
             </form>
-            <form onSubmit={(e) => {
-              e.preventDefault();
-              handleOAuthSignIn("github");
-              }}>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleOAuthSignIn("github");
+              }}
+            >
               <div className="-mx-3 flex flex-wrap">
                 <div className="mt-3 w-full px-3">
                   <Button

--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -76,7 +76,10 @@ export default function SignIn() {
           </div>
 
           <div className="mx-auto max-w-sm">
-            <form onSubmit={(e) => handleOAuthSignIn("google")}>
+            <form onSubmit={(e) => {
+              e.preventDefault();
+              handleOAuthSignIn("google");
+              }}>
               <Button
                 type="submit"
                 size="lg"
@@ -87,7 +90,10 @@ export default function SignIn() {
                 <span className="">Sign in with Google</span>
               </Button>
             </form>
-            <form onSubmit={(e) => handleOAuthSignIn("github")}>
+            <form onSubmit={(e) => {
+              e.preventDefault();
+              handleOAuthSignIn("github");
+              }}>
               <div className="-mx-3 flex flex-wrap">
                 <div className="mt-3 w-full px-3">
                   <Button

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -94,7 +94,10 @@ export default function SignUp() {
           </div>
 
           <div className="mx-auto max-w-sm">
-            <form onSubmit={(e) => handleOAuthSignUp("google")}>
+            <form onSubmit={(e) => {
+              e.preventDefault();
+              handleOAuthSignUp("google");
+              }}>
               <Button
                 type="submit"
                 size="lg"
@@ -105,7 +108,10 @@ export default function SignUp() {
                 <span>Sign up with Google</span>
               </Button>
             </form>
-            <form onSubmit={(e) => handleOAuthSignUp("github")}>
+            <form onSubmit={(e) => {
+              e.preventDefault();
+              handleOAuthSignUp("github");
+              }}>
               <div className="-mx-3 flex flex-wrap">
                 <div className="mt-3 w-full px-3">
                   <Button

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -94,10 +94,12 @@ export default function SignUp() {
           </div>
 
           <div className="mx-auto max-w-sm">
-            <form onSubmit={(e) => {
-              e.preventDefault();
-              handleOAuthSignUp("google");
-              }}>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleOAuthSignUp("google");
+              }}
+            >
               <Button
                 type="submit"
                 size="lg"
@@ -108,10 +110,12 @@ export default function SignUp() {
                 <span>Sign up with Google</span>
               </Button>
             </form>
-            <form onSubmit={(e) => {
-              e.preventDefault();
-              handleOAuthSignUp("github");
-              }}>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleOAuthSignUp("github");
+              }}
+            >
               <div className="-mx-3 flex flex-wrap">
                 <div className="mt-3 w-full px-3">
                   <Button


### PR DESCRIPTION
### Description
**Problem**
OAuth login/signup buttons do not work on mobile, and are inconsistent on desktop

**Root cause**
Form submission events will submit data and reload the page by default. This causes inconsistency with the login/signup for google and github because the forms can set off a page reload before we could redirect to oauth.

**Solution**
Prevent default action when submitting in OAuth forms

### Related Issue

#217 

### Changes Made

* Added `Event.preventDefault()` method call before calling `handleOAuthSignIn("provider")` or `handleOAuthSignUp("provider")`. 

### Screenshots

https://github.com/user-attachments/assets/e004a16d-7922-4fe3-b864-6affeaa9ab50

https://github.com/user-attachments/assets/a0165dd9-7d49-4ff2-b019-3efece9a5fef

### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
