### PR TITLE
Added disclaimer to "Open PearAI" button in subscription card

### DIFF
--- a/components/dashboard/subscription-card.tsx
+++ b/components/dashboard/subscription-card.tsx
@@ -23,6 +23,7 @@ import {
 import { useState } from "react";
 import { useCancelSubscription } from "@/hooks/useCancelSubscription";
 import { User } from "@supabase/supabase-js";
+import { Info } from "lucide-react";
 
 type SubscriptionCardProps = {
   subscription: Subscription | null;
@@ -160,6 +161,20 @@ export default function SubscriptionCard({
                   Open PearAI
                 </Link>
               </Button>
+              <div className="mt-1 flex items-center">
+                <Info className="inline text-muted-foreground" size={14} />
+                <p className="ml-1.5 block text-xs text-muted-foreground">
+                  Make sure PearAI is{" "}
+                  <Button
+                    variant="link"
+                    asChild
+                    className="p-0 text-xs text-primary-800"
+                  >
+                    <Link href="/pricing">installed.</Link>
+                  </Button>{" "}
+                  Use this button to open the app and login directly.
+                </p>
+              </div>
             </div>
             <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
               <DialogTrigger asChild>


### PR DESCRIPTION
### Description

Added disclaimer to button in subscription card so it is the same as free-trial card

### Related issue
#224

### Changes Made

- Added disclaimer to button in subscription card

### Screenshots
![image](https://github.com/user-attachments/assets/d94d8b2c-fa77-4cf3-8569-069b6ccd97d9)

### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
