### PR TITLE
fix - disable resub sub button because it doesn't work

### DIFF
--- a/components/dashboard/subscription-card.tsx
+++ b/components/dashboard/subscription-card.tsx
@@ -180,14 +180,14 @@ export default function SubscriptionCard({
               <DialogTrigger asChild>
                 <Button
                   onClick={handleCancelClick}
-                  disabled={isCanceling}
+                  disabled={isCanceling || isCanceled}
                   variant="link"
                   className="px-0"
                 >
                   {isCanceling
                     ? "Canceling..."
                     : isCanceled
-                      ? "Subscription canceled, reactivate?"
+                      ? "Subscription canceled"
                       : "Cancel Subscription"}
                 </Button>
               </DialogTrigger>


### PR DESCRIPTION

## Current
<img width="700" alt="Screenshot 2024-08-28 at 11 33 21 PM" src="https://github.com/user-attachments/assets/b7b616cd-1130-4e58-97fa-e2c4e01064f7">

But we can't resubscribe (we don't have it implemented and we prevent users from subscribing if they are already subbed)
<img width="381" alt="Screenshot 2024-08-28 at 11 33 54 PM" src="https://github.com/user-attachments/assets/2d0a88a4-7984-4db5-98fc-d859d5d1ec04">

## After
<img width="686" alt="Screenshot 2024-08-28 at 11 34 39 PM" src="https://github.com/user-attachments/assets/5d2923d6-4084-4637-8f5f-c5076568cc1c">
