### PR TITLE
Changed download to server side streaming to avoid browser inconsistency

### DIFF
--- a/app/api/download/route.ts
+++ b/app/api/download/route.ts
@@ -1,5 +1,3 @@
-import { createClient } from "@/utils/supabase/server";
-import { withAuth } from "@/utils/withAuth";
 import { NextRequest, NextResponse } from "next/server";
 
 async function downloadFile(request: NextRequest) {
@@ -9,31 +7,33 @@ async function downloadFile(request: NextRequest) {
       `${process.env.PEARAI_SERVER_URL}/download?os_type=${os_type}`,
       {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
       },
     );
 
-    const { download_link } = await res.json();
-
-    if (!res.ok || !download_link) {
-      return NextResponse.json(
-        { error: "Failed to get download file from server" },
-        { status: 500 },
-      );
+    if (!res.ok) {
+      const errorData = await res.json();
+      const errorMessage =
+        errorData.error ??
+        `Server responded with ${res.status}: ${res.statusText}`;
+      throw new Error(errorMessage);
     }
 
-    return NextResponse.json({ url: download_link });
+    // Forward the response from the Python backend
+    const blob = await res.blob();
+    return new NextResponse(blob, {
+      status: 200,
+      headers: {
+        "Content-Type":
+          res.headers.get("Content-Type") ?? "application/octet-stream",
+        "Content-Disposition":
+          res.headers.get("Content-Disposition") ??
+          `attachment; filename="PearAI-${os_type}-installer.dmg"`,
+        "X-Download-URL": res.headers.get("X-Download-URL") ?? "",
+      },
+    });
   } catch (error: any) {
-    let errMsg = "Error downloading file: ";
-    if (error instanceof Error) {
-      errMsg += `: ${error?.message}`;
-    } else if (typeof error === "string") {
-      errMsg += `: ${error}`;
-    }
-
-    return NextResponse.json({ error: errMsg }, { status: 500 });
+    console.error("Download error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }
 

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -91,7 +91,6 @@ const PricingTier: React.FC<PricingTierProps> = ({
       // Clean up
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
-      console.log(res.headers.get("X-Download-URL"));
       setDownloadLink(res.headers.get("X-Download-URL") ?? "None");
       setDownloaded(true);
     } catch (error: any) {

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
   Card,
   CardContent,
@@ -8,12 +8,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Check, Download } from "lucide-react";
+import { Check } from "lucide-react";
 import Link from "next/link";
 import { useCheckout } from "@/hooks/useCheckout";
 import { PRICING_TIERS, CONTACT_EMAIL } from "@/utils/constants";
 import { PricingPageProps, PricingTierProps } from "@/types/pricing";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import Spinner from "./ui/spinner";
 import { Badge } from "./ui/badge";
@@ -55,27 +54,45 @@ const PricingTier: React.FC<PricingTierProps> = ({
   const [downloaded, setDownloaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [downloadLink, setDownloadLink] = useState<string>();
-  const router = useRouter();
 
   const handleDownload = async (os_type: string) => {
     setIsLoading(true);
     try {
       const res = await fetch(`/api/download?os_type=${os_type}`, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
       });
 
       if (!res.ok) {
-        throw Error(res.statusText);
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(errorData?.error ?? res.statusText);
       }
 
-      const download = await res.json();
-      if (download?.url) {
-        setDownloadLink(download.url);
-        router.push(download.url);
-      }
+      // Get the blob from the response
+      const blob = await res.blob();
+
+      // Create a temporary URL for the blob
+      const url = window.URL.createObjectURL(blob);
+
+      // Get the filename from the Content-Disposition header
+      const contentDisposition = res.headers.get("Content-Disposition");
+      const filenameMatch = contentDisposition?.match(/filename="?(.+)"?/i);
+      const filename = filenameMatch
+        ? filenameMatch[1]
+        : `PearAI-${os_type}-installer.dmg`;
+
+      // Create a temporary anchor element and trigger the download
+      // This method is used to ensure consistency across browsers
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+
+      // Clean up
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+      console.log(res.headers.get("X-Download-URL"));
+      setDownloadLink(res.headers.get("X-Download-URL") ?? "None");
       setDownloaded(true);
     } catch (error: any) {
       toast.error(error.message);
@@ -173,20 +190,23 @@ const PricingTier: React.FC<PricingTierProps> = ({
             {isFree ? (
               downloaded ? (
                 <p className="text-sm font-medium text-gray-400 sm:text-base">
-                  Thank you for downloading PearAI! Your download should have
-                  started! :)
+                  Thank you for downloading PearAI! Your download is now
+                  completed.
                   <br />
                   <br />
-                  If it didn&apos;t, you can click{" "}
+                  If there was an issue, you can click{" "}
                   {downloadLink && (
                     <Link href={downloadLink} className="text-link">
                       here
                     </Link>
-                  )}
-                  .
+                  )}{" "}
+                  to download again.
                 </p>
               ) : isLoading ? (
-                <div className="flex justify-center">
+                <div className="flex flex-col items-center space-y-3">
+                  <p className="text-s mt-2 text-gray-400">
+                    Download in progress... Please hold!
+                  </p>
                   <Spinner />
                 </div>
               ) : (


### PR DESCRIPTION
Previous download method was having errors due to directly providing CDN link. Some browsers would not work e.g. Firefox, and sometimes Safari.

Changed the download to happen from our own server side through streaming, and provide app directly to landing page.

Means landing page upon clicking download, will have a spinner that hangs for a bit saying download in progress. Then app is directly available. Will no longer see progress bar on the top right browser download place.

TODO: we should have our own progress tracker bar on the landing page so user knows how long left and not bugged out.

Con of this method: more load on server since server has to perform the download from digital ocean.

Describe what this PR does.

Tested locally, download working on safari, firefox and chrome. Intel download takes longer than the others.