### PR TITLE
fix(pricing): download logo display issue in Safari

### DIFF
--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -90,12 +90,12 @@ const PricingTier: React.FC<PricingTierProps> = ({
         <div className="flex w-[10%] items-center justify-start md:w-[20%]">
           <div className="hidden h-10 w-10 items-center justify-center rounded-full bg-primary-1000 text-primary-700 md:flex">
             {os.os !== "windows" ? (
-              <span className="flex h-5 w-5 items-center justify-center">
-                <AppleLogo />
+              <span className="flex items-center justify-center">
+                <AppleLogo className="h-5 w-5" />
               </span>
             ) : (
-              <span className="flex h-5 w-5 items-center justify-center">
-                <WindowsLogo />
+              <span className="flex items-center justify-center">
+                <WindowsLogo className="h-5 w-5" />
               </span>
             )}
           </div>


### PR DESCRIPTION
### Description

This PR fixes the brand logo display issue on pricing page in Safari

### Changes Made

- Explicitly applied height and width to SVG

### Screenshots

Before:
![Screenshot 2024-09-01 at 1 06 27 PM](https://github.com/user-attachments/assets/a81c0353-c69a-475d-82d6-2bf15c93ba1f)

After:
![Screenshot 2024-09-01 at 1 05 42 PM](https://github.com/user-attachments/assets/4f03a84a-c40a-4182-90fe-95b6884a5ca3)

### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
