### PR TITLE
feat(blog): add author and reading time to posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,7 +4,6 @@ import { format, parseISO } from "date-fns";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import readingTime from "reading-time";
 
 export const generateStaticParams = async () =>
   allPosts.map((post) => ({ slug: post.slug }));
@@ -30,7 +29,6 @@ const PostLayout = ({ params }: { params: { slug: string } }) => {
   if (!post) notFound();
 
   const author = allAuthors.find(({ github }) => github === post.author);
-  const postReadingTime = readingTime(post.body.raw);
 
   return (
     <article className="mx-auto max-w-prose px-4 py-8 pt-32 sm:px-6">
@@ -59,7 +57,7 @@ const PostLayout = ({ params }: { params: { slug: string } }) => {
             <time dateTime={post.date} className="mb-0.5 block text-sm">
               {format(parseISO(post.date), "LLLL d, yyyy")}
             </time>
-            <span>{postReadingTime.text}</span>
+            <span>{post.readingTime}</span>
           </div>
         </div>
         <div className="relative mt-6 aspect-video w-full rounded-md bg-gray-300">

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -1,5 +1,6 @@
 import { Post } from "@/.contentlayer/generated";
 import { format, parseISO } from "date-fns";
+import { DotIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -17,12 +18,13 @@ const PostCard = (post: Post) => (
       />
     </div>
 
-    <time
-      dateTime={post.date}
-      className="block text-xs tracking-[0.01rem] text-gray-600 dark:text-gray-600"
-    >
-      {format(parseISO(post.date), "LLLL d, yyyy")}
-    </time>
+    <div className="flex items-center text-xs text-gray-600 dark:text-gray-600">
+      <time dateTime={post.date} className="block tracking-[0.01rem]">
+        {format(parseISO(post.date), "LLLL d, yyyy")}
+      </time>
+      <DotIcon className="h-5 w-5" />
+      <span>{post.readingTime}</span>
+    </div>
     <h2 className="mb-2 mt-1.5 text-xl font-semibold">{post.title}</h2>
     <p className="line-clamp-3 text-sm text-gray-700 dark:text-gray-600">
       {post.excerpt}

--- a/content/authors/nang.md
+++ b/content/authors/nang.md
@@ -1,0 +1,4 @@
+---
+name: nang
+github: nang-dev
+---

--- a/content/posts/how-we-designed-our-servers-end-to-end-for-pearai.md
+++ b/content/posts/how-we-designed-our-servers-end-to-end-for-pearai.md
@@ -3,6 +3,7 @@ title: "How We Designed Our Servers at PearAI"
 date: 2024-09-01
 excerpt: I spent the last 2 months working on PearAI, an Open-Sourced AI-Powered Code Editor. It is like having an expert on your codebase right next to you. We achieve this with Retrieval Augmented Generation. This is my new startup after finishing my B.S. & M.S from Carnegie Mellon and working for 1.5 years in High Frequency Trading as a Software Engineer. This is exactly how we designed our server.
 thumbnail: "/images/og-image.png"
+author: nang-dev
 tags: ["server", "server design", "pearai server"]
 ---
 

--- a/content/posts/setting-up-auto-complete-on-pearai.md
+++ b/content/posts/setting-up-auto-complete-on-pearai.md
@@ -3,6 +3,7 @@ title: "Setting Up Auto-Complete On PearAI"
 date: 2024-08-31
 excerpt: PearAI supports tab autocomplete, and this is how to set this up. Tab autocomplete predicts / suggests what you would type next as you’re coding!
 thumbnail: "/images/og-image.png"
+author: nang-dev
 tags: ["autocomplete", "suggestions"]
 ---
 

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -4,7 +4,7 @@ import rehypePrettyCode from "rehype-pretty-code";
 
 export const Post = defineDocumentType(() => ({
   name: "Post",
-  filePathPattern: `**/*.md`,
+  filePathPattern: `posts/**/*.md`,
   fields: {
     title: { type: "string", required: true },
     date: { type: "date", required: true },
@@ -18,18 +18,43 @@ export const Post = defineDocumentType(() => ({
       },
       required: false,
     },
+    author: {
+      type: "string", // GitHub handle of the author
+      required: true,
+    },
   },
   computedFields: {
     url: {
       type: "string",
-      resolve: (post) => `/blog/${post._raw.flattenedPath}`,
+      resolve: (post) =>
+        `/blog/${post._raw.flattenedPath.split("/").slice(1).join("/")}`,
+    },
+    slug: {
+      type: "string",
+      resolve: (post) => post._raw.flattenedPath.split("/").slice(1).join("/"),
+    },
+  },
+}));
+
+export const Author = defineDocumentType(() => ({
+  name: "Author",
+  filePathPattern: `authors/**/*.md`,
+  contentType: "markdown",
+  fields: {
+    name: {
+      type: "string",
+      required: true,
+    },
+    github: {
+      type: "string",
+      required: true,
     },
   },
 }));
 
 export default makeSource({
-  contentDirPath: "posts",
-  documentTypes: [Post],
+  contentDirPath: "content",
+  documentTypes: [Post, Author],
   markdown: {
     remarkPlugins: [remarkGfm],
     rehypePlugins: [

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -1,6 +1,7 @@
 import { defineDocumentType, makeSource } from "contentlayer/source-files";
 import remarkGfm from "remark-gfm";
 import rehypePrettyCode from "rehype-pretty-code";
+import readingTime from "reading-time";
 
 export const Post = defineDocumentType(() => ({
   name: "Post",
@@ -32,6 +33,10 @@ export const Post = defineDocumentType(() => ({
     slug: {
       type: "string",
       resolve: (post) => post._raw.flattenedPath.split("/").slice(1).join("/"),
+    },
+    readingTime: {
+      type: "string",
+      resolve: (post) => readingTime(post.body.raw).text,
     },
   },
 }));

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
     remotePatterns: [
       { protocol: "https", hostname: "pbs.twimg.com" },
       { protocol: "https", hostname: "abs.twimg.com" },
+      { protocol: "https", hostname: "github.com" },
     ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-hook-form": "^7.52.0",
     "react-hook-use-form": "^1.2.0",
     "react-tweet": "^3.2.1",
+    "reading-time": "^1.5.0",
     "shiki": "0.11.1",
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.3.0",


### PR DESCRIPTION
### Description

Added support for including an author and reading time field in Contentlayer blog posts, allowing for better author attribution and organization.

### Changes Made

- Introduced an author field in the Contentlayer schema for blog posts.
- Updated existing blog posts to include the new author and read time field.
- Modified templates to display the author information in the post view.

## Screenshots
![Screenshot 2024-09-02 at 10 35 01 PM](https://github.com/user-attachments/assets/9c585ae9-952c-4dcf-a592-9f078abf7f87)
![Screenshot 2024-09-02 at 10 35 08 PM](https://github.com/user-attachments/assets/ed84e960-1d67-4ba5-9f11-12174a839da6)
![Screenshot 2024-09-02 at 10 35 34 PM](https://github.com/user-attachments/assets/4d3f4b17-ffd6-4982-919b-1f708621328a)
![Screenshot 2024-09-02 at 10 35 39 PM](https://github.com/user-attachments/assets/64b738ca-444d-454f-8066-3ec12a0d6497)

### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
