### PR TITLE
fix 'Open PearAI' button

### DIFF
--- a/components/dashboard/freetrial-card.tsx
+++ b/components/dashboard/freetrial-card.tsx
@@ -73,6 +73,7 @@ export default function FreeTrialCard({
               <Button variant="outline" className="text-primary-800" asChild>
                 <Link
                   href={DEFAULT_OPEN_APP_CALLBACK + "?" + openAppQueryParams}
+                  target="_parent"
                 >
                   Open PearAI
                 </Link>

--- a/components/dashboard/subscription-card.tsx
+++ b/components/dashboard/subscription-card.tsx
@@ -166,6 +166,7 @@ export default function SubscriptionCard({
               <Button variant="outline" className="text-primary-800" asChild>
                 <Link
                   href={DEFAULT_OPEN_APP_CALLBACK + "?" + openAppQueryParams}
+                  target="_parent"
                 >
                   Open PearAI
                 </Link>


### PR DESCRIPTION
(My first PR)
### Description
This PR changes the `target` attribute from a default `_self` to `_parent`, which changes the `frame` in which the link is opened.

### Related Issue
#263 

### Changes Made

This PR changes the `target` attribute from a default `_self` to `_parent`, which changes the `frame` in which the link is opened.

### Video

That's how it works after fixing

https://github.com/user-attachments/assets/00192250-b8c6-4ccd-95f4-dd9a2b5abdc8



### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
