### PR TITLE
fix open links in new tab, not the same

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -23,9 +23,13 @@ export default function Footer() {
           <div key={idx}>
             <h5 className="font-semibold">{title}</h5>
             <ul className="mt-4 space-y-2 text-neutral-500 dark:text-neutral-400">
-              {links.map(({ text, href }, idx) => (
+              {links.map(({ text, href, target = "_self" }, idx) => (
                 <li key={idx}>
-                  <Link href={href} className="text-sm hover:text-primary-600">
+                  <Link
+                    href={href}
+                    target={target}
+                    className="text-sm hover:text-primary-600"
+                  >
                     {text}
                   </Link>
                 </li>

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -17,11 +17,20 @@ import MobileMenu from "./mobile-menu";
 import { redirect } from "next/navigation";
 import { createClient } from "@/utils/supabase/server";
 
-const NavItem = ({ href, children }: { href: string; children: ReactNode }) => (
+const NavItem = ({
+  href,
+  target = "_self",
+  children,
+}: {
+  href: string;
+  target?: React.HTMLAttributeAnchorTarget;
+  children: ReactNode;
+}) => (
   <NavigationMenuLink
     asChild
     className={navigationMenuTriggerStyle()}
     href={href}
+    target={target}
   >
     <Link href={href}>{children}</Link>
   </NavigationMenuLink>
@@ -119,7 +128,10 @@ export default async function Header() {
                       </DropdownNavItem>
                       <NavItem href="/pricing">Pricing / Download</NavItem>
                       <NavItem href="/docs">Documentation</NavItem>
-                      <NavItem href="https://github.com/trypear/pearai-app">
+                      <NavItem
+                        href="https://github.com/trypear/pearai-app"
+                        target="_blank"
+                      >
                         GitHub ⭐️
                       </NavItem>
                     </NavigationMenuList>

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -167,6 +167,7 @@ export const footerSections = [
       {
         text: "Discord",
         href: "https://discord.gg/7QMraJUsQt",
+        target: "_blank",
       },
     ],
   },


### PR DESCRIPTION
### Description

Adds `target="_blank"` to links

### Related Issue

#266 

### Changes Made

Added `target="_blank"` to links

### Video

https://github.com/user-attachments/assets/2f66d5e7-4434-471b-b9d3-48f9428c3967




### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
