### PR TITLE
moved (i) button to the left side of the text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules/
 
 # contentlayer
 .contentlayer
+
+.env

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -109,7 +109,7 @@ const PricingTier: React.FC<ExtendedPricingTierProps> = ({
     if (feature?.startsWith("custom-standard")) {
       return (
         <div className="flex items-center">
-          <span className="inline-flex items-center">
+          <span>
             Monthly refill of PearAI Credits for market-leading AI models
             <PearCreditsTooltip type="standard" />
           </span>
@@ -117,8 +117,8 @@ const PricingTier: React.FC<ExtendedPricingTierProps> = ({
       );
     } else if (feature?.startsWith("custom-enterprise")) {
       return (
-        <div className="flex items-center">
-          <span className="inline-flex items-center">
+        <div className="flex items-center"> 
+          <span>
             Monthly refill of increased PearAI Credits for market-leading AI
             models
             <PearCreditsTooltip type="enterprise" />

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -457,7 +457,7 @@ export const PearCreditsTooltip = ({ type }: { type: string }) => {
       <Tooltip open={isOpen} onOpenChange={setIsOpen} delayDuration={50}>
         <TooltipTrigger asChild>
           <Info
-            className="ml-1 inline-flex h-4 w-4 flex-shrink-0 cursor-pointer"
+            className="mb-0.5 ml-1 inline-flex h-4 w-4 flex-shrink-0 cursor-pointer"
             onClick={() => setIsOpen((prev) => !prev)}
           />
         </TooltipTrigger>

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -117,7 +117,7 @@ const PricingTier: React.FC<ExtendedPricingTierProps> = ({
       );
     } else if (feature?.startsWith("custom-enterprise")) {
       return (
-        <div className="flex items-center"> 
+        <div className="flex items-center">
           <span>
             Monthly refill of increased PearAI Credits for market-leading AI
             models

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
### Description

move the (i) button to the left side, right after the text

### Related Issue


### Changes Made

removed ```inline-flex``` and ```items-center```

### Screenshots

Standard 
<img width="545" alt="Screenshot 2024-09-04 at 5 06 04 PM" src="https://github.com/user-attachments/assets/732750b0-f2f8-4a3c-bbc6-38ff450de196">

Enterprise

<img width="570" alt="Screenshot 2024-09-04 at 5 01 36 PM" src="https://github.com/user-attachments/assets/c2da143b-4dd6-4f75-9012-f2c1c2de1b45">



### Checklist

- [ ] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [x] I have added necessary documentation (if applicable)
