### PR TITLE
Add "Show Password" Checkbox to Forms

### DIFF
--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -67,6 +67,12 @@ export default function SignIn() {
     }
   };
 
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const handleCheckboxChange = () => {
+    setIsPasswordVisible(!isPasswordVisible);
+  };
+
   return (
     <section className="relative">
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
@@ -157,7 +163,7 @@ export default function SignIn() {
                       <FormControl>
                         <Input
                           id="password"
-                          type="password"
+                          type={isPasswordVisible ? "text" : "password"}
                           placeholder="********"
                           {...field}
                         />
@@ -166,6 +172,17 @@ export default function SignIn() {
                     </FormItem>
                   )}
                 />
+
+                <Label className="flex items-center">
+                  <Checkbox
+                    className="rounded"
+                    checked={isPasswordVisible}
+                    onCheckedChange={handleCheckboxChange}
+                  />
+                  <span className="ml-2 cursor-pointer text-gray-600">
+                    Show Password
+                  </span>
+                </Label>
 
                 <div className="flex justify-between">
                   <Label className="flex items-center">

--- a/components/auth/signin.tsx
+++ b/components/auth/signin.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/form";
 import { SignInFormData, signInSchema } from "@/utils/form-schema";
 import { useSearchParams } from "next/navigation";
+import { useToggle } from "@/hooks/useToggle";
 
 export default function SignIn() {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -67,11 +68,7 @@ export default function SignIn() {
     }
   };
 
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-
-  const handleCheckboxChange = () => {
-    setIsPasswordVisible(!isPasswordVisible);
-  };
+  const [isPasswordVisible, togglePasswordVisibility] = useToggle(false);
 
   return (
     <section className="relative">
@@ -172,18 +169,16 @@ export default function SignIn() {
                     </FormItem>
                   )}
                 />
-
                 <Label className="flex items-center">
                   <Checkbox
                     className="rounded"
                     checked={isPasswordVisible}
-                    onCheckedChange={handleCheckboxChange}
+                    onCheckedChange={togglePasswordVisibility}
                   />
                   <span className="ml-2 cursor-pointer text-gray-600">
                     Show Password
                   </span>
                 </Label>
-
                 <div className="flex justify-between">
                   <Label className="flex items-center">
                     <Checkbox className="rounded" />

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { useToggle } from "@/hooks/useToggle";
 
 export default function SignUp() {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -84,12 +85,7 @@ export default function SignUp() {
       setErrorMessage("An unexpected error occurred. Please try again.");
     }
   };
-
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-
-  const handleCheckboxChange = () => {
-    setIsPasswordVisible(!isPasswordVisible);
-  };
+  const [isPasswordVisible, togglePasswordVisibility] = useToggle(false);
 
   return (
     <section className="relative">
@@ -233,7 +229,7 @@ export default function SignUp() {
                   <Checkbox
                     className="rounded"
                     checked={isPasswordVisible}
-                    onCheckedChange={handleCheckboxChange}
+                    onCheckedChange={togglePasswordVisibility}
                   />
                   <span className="ml-2 cursor-pointer text-gray-600">
                     Show Password

--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -19,6 +19,8 @@ import {
 import { signUpSchema, SignUpFormData } from "@/utils/form-schema";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 
 export default function SignUp() {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -81,6 +83,12 @@ export default function SignUp() {
     } catch (error) {
       setErrorMessage("An unexpected error occurred. Please try again.");
     }
+  };
+
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const handleCheckboxChange = () => {
+    setIsPasswordVisible(!isPasswordVisible);
   };
 
   return (
@@ -211,7 +219,7 @@ export default function SignUp() {
                       <FormControl>
                         <Input
                           id="password"
-                          type="password"
+                          type={isPasswordVisible ? "text" : "password"}
                           placeholder="Password (at least 8 characters)"
                           {...field}
                         />
@@ -220,6 +228,17 @@ export default function SignUp() {
                     </FormItem>
                   )}
                 />
+
+                <Label className="flex items-center">
+                  <Checkbox
+                    className="rounded"
+                    checked={isPasswordVisible}
+                    onCheckedChange={handleCheckboxChange}
+                  />
+                  <span className="ml-2 cursor-pointer text-gray-600">
+                    Show Password
+                  </span>
+                </Label>
 
                 <div className="text-center text-sm text-gray-600">
                   <Link

--- a/hooks/useToggle.ts
+++ b/hooks/useToggle.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+export function useToggle(
+  initialState: boolean = false,
+): [boolean, () => void] {
+  const [state, setState] = useState<boolean>(initialState);
+
+  const toggle = useCallback(() => {
+    setState((state) => !state);
+  }, []);
+
+  return [state, toggle];
+}


### PR DESCRIPTION
This PR adds a "Show Password" checkbox below the password input fields in both forms. When the checkbox is checked, the password field's type changes to `text` , allowing users to see their password. When unchecked, the field type changes back to `password`, hiding the input text.

![off](https://github.com/user-attachments/assets/5b920be8-e23b-4365-a9dc-dd5dca8031f6)

![on](https://github.com/user-attachments/assets/89fdc9a3-8de2-4c2b-b5ff-083a1b76c4fa)
