### PR TITLE
fix: scroll bar hiding on pricing page #281

### DIFF
--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -266,7 +266,7 @@ const PricingTier: React.FC<ExtendedPricingTierProps> = ({
                   </Button>
                 </div>
                 <div className="flex w-full max-w-md">
-                  <DropdownMenu>
+                  <DropdownMenu modal={false}>
                     <DropdownMenuTrigger asChild>
                       <Button
                         ref={buttonRef}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
### Description

scroll bar is till appeared after triggering drop down menu.

### Related Issue

#281

### Changes Made

added modal tag for `DropdownMenu` tag, related fix radix-ui: https://github.com/radix-ui/primitives/issues/1272#issuecomment-1136899602

### Screenshots

![image](https://github.com/user-attachments/assets/7090f88b-66d6-4e5a-a7b9-012e7ceedda8)

### Checklist

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and build is successful
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable)
