### PR TITLE
Update mobile-menu.tsx

### DIFF
--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -161,6 +161,12 @@ export default function MobileMenu({
                         Documentation
                       </MobileNavItem>
                       <MobileNavItem
+                        href="https://github.com/trypear/pearai-master"
+                        onClick={() => setIsOpen(false)}
+                      >
+                        Github
+                      </MobileNavItem>
+                      <MobileNavItem
                         href="/blog"
                         onClick={() => setIsOpen(false)}
                       >


### PR DESCRIPTION
### Description

I added Github to the mobile menu on the side

### Related Issue

#364 

### Changes Made

I added Github to the mobile menu on the side
### Screenshots
Before
<img width="613" alt="Screenshot 2024-11-15 at 3 29 51 PM" src="https://github.com/user-attachments/assets/9406366e-88ff-4410-8338-317b63e9a279">

After
<img width="838" alt="Screenshot 2024-11-15 at 3 28 47 PM" src="https://github.com/user-attachments/assets/2a730823-2ddd-4435-a0ed-652035c97176">

### **### Now I will mention who ever reviews this needs to take in to consideration how they think it looks, I personally find it fine but if you find it cluttered please let me know and I'll be happy to keep working I just want to try and help make the website better.** 

The lighting button Clips when the resources tab is open (From testing on my computer not phone) depends if you are Ok with that. Imo it looks fine.