### PR TITLE
1.6.1 version release date fix

### DIFF
--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -46,11 +46,11 @@ type VersionInfo = {
 export const platformVersions: Record<string, VersionInfo> = {
   Windows: {
     version: "v1.6.1",
-    releaseDate: "Dec 5, 2024",
+    releaseDate: "Dec 26, 2024",
   },
   "Mac (M chip)": {
     version: "v1.6.1",
-    releaseDate: "Dec 5, 2024",
+    releaseDate: "Dec 26, 2024",
   },
   "Mac (Intel)": {
     version: "v1.5.4",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update release dates for Windows and Mac (M chip) in `platformVersions` to December 26, 2024.
> 
>   - **Behavior**:
>     - Update `releaseDate` for `Windows` and `Mac (M chip)` in `platformVersions` from `Dec 5, 2024` to `Dec 26, 2024`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpear-landing-page&utm_source=github&utm_medium=referral)<sup> for e00e4ca6cd1d37cbdc0aa94d2d6f9037f66eb9a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->