### PR TITLE
fix(form): resolve color coding issue in 'Windows' form dropdown (#405)

### DIFF
--- a/components/ui/download-feedback-form.tsx
+++ b/components/ui/download-feedback-form.tsx
@@ -71,7 +71,7 @@ export default function DownloadFeedbackForm({
                 Select a role...
               </option>
               {userRoles.map((r) => (
-                <option key={r} value={r}>
+                <option key={r} value={r} className="dark: text-slate-800">
                   {r}
                 </option>
               ))}
@@ -91,7 +91,11 @@ export default function DownloadFeedbackForm({
                 Select experience level...
               </option>
               {experienceLevels.map((level) => (
-                <option key={level} value={level}>
+                <option
+                  key={level}
+                  value={level}
+                  className="dark: text-slate-800"
+                >
                   {level}
                 </option>
               ))}
@@ -111,7 +115,7 @@ export default function DownloadFeedbackForm({
                 Select primary use...
               </option>
               {primaryUses.map((use) => (
-                <option key={use} value={use}>
+                <option key={use} value={use} className="dark: text-slate-800">
                   {use}
                 </option>
               ))}

--- a/components/ui/download-feedback-form.tsx
+++ b/components/ui/download-feedback-form.tsx
@@ -71,7 +71,7 @@ export default function DownloadFeedbackForm({
                 Select a role...
               </option>
               {userRoles.map((r) => (
-                <option key={r} value={r} className="dark: text-slate-800">
+                <option key={r} value={r} className="dark:text-slate-800">
                   {r}
                 </option>
               ))}
@@ -94,7 +94,7 @@ export default function DownloadFeedbackForm({
                 <option
                   key={level}
                   value={level}
-                  className="dark: text-slate-800"
+                  className="dark:text-slate-800"
                 >
                   {level}
                 </option>
@@ -115,7 +115,7 @@ export default function DownloadFeedbackForm({
                 Select primary use...
               </option>
               {primaryUses.map((use) => (
-                <option key={use} value={use} className="dark: text-slate-800">
+                <option key={use} value={use} className="dark:text-slate-800">
                   {use}
                 </option>
               ))}


### PR DESCRIPTION
### **Description**

This PR fixes the color coding issue in the "Windows" form dropdown under the downloads section. The text was appearing white until hovered, causing visibility issues in dark mode. The dropdown text color is now adjusted for better readability.

---

### **Related Issue**

Fixes #405 

---

### **Changes Made**

- File modified :- /components/ui/download-feedback-form.tsx
- Adjusted the dropdown text color for the "Windows" form. 
- Ensured the changes comply with dark mode styling.

---

### **Screenshots**

#### **Before Fix:**
![Before Fix](https://github.com/user-attachments/assets/30f03c8c-2aeb-4525-99e0-ba0a0e8a573a)

#### **After Fix:**
![After Fix](https://github.com/user-attachments/assets/4e11cbaf-0dc6-454d-87c9-09b4df09f28f)

---

### **Checklist**

- [x] I have tagged the issue in this PR.
- [x] I have attached necessary screenshots.
- [x] I have provided a short description of the PR.
- [x] I ran `yarn build` and the build was successful.
- [x] My code follows the style guidelines of this project.
- [ ] I have added necessary documentation (if applicable).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes dropdown text color in `download-feedback-form.tsx` for better visibility in dark mode.
> 
>   - **UI Fix**:
>     - Adjusts dropdown text color in `download-feedback-form.tsx` for better visibility in dark mode.
>     - Applies `className="dark: text-slate-800"` to `<option>` elements for `userRoles`, `experienceLevels`, and `primaryUses`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpear-landing-page&utm_source=github&utm_medium=referral)<sup> for aa61baf306e2197c7fa295b4c198ca4a395fdf83. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->